### PR TITLE
Support `updates` command for both private GitHub repos and non-GitHub repos.

### DIFF
--- a/utils/git.sh
+++ b/utils/git.sh
@@ -74,45 +74,26 @@ function updates {
 		local reponame=`basename $repo`
 		pending 'checking' $reponame
 		if [ -z "$B_PRETEND" ]; then
-			local reponame=$(get_github_reponame $reponame)
 			local ref=$(cd $repo; git symbolic-ref HEAD 2>/dev/null)
-			if [ -n "$reponame" ]; then
-				local remote_head=$(get_repo_head $reponame $ref)
+			local remote_url=$(cd $repo; git config remote.origin.url 2>/dev/null)
+			local remote_head=$(git ls-remote -q --heads "$remote_url" "$ref" 2>/dev/null | cut -f 1)
+			if [ -n "$remote_head" ]; then
 				local local_head=$(cd $repo; git rev-parse HEAD)
 				if [ "$remote_head" == "$local_head" ]; then
 					success 'up to date'
 				else
-					if [ "$remote_head" ]; then
-						(cd $repo; git branch --contains "$remote_head") > /dev/null
-						if [ "$?" == "0" ]; then
-							fail 'ahead'
-						else
-							fail 'behind'
-						fi
+					(cd $repo; git branch --contains "$remote_head" 2>/dev/null) > /dev/null
+					if [ "$?" == "0" ]; then
+						fail 'ahead'
 					else
-						ignore 'private'
+						fail 'behind'
 					fi
 				fi
 			else
-				ignore 'not github'
+				ignore 'uncheckable'
 			fi
 		else
 			success 'checked'
 		fi
 	done
-}
-
-function get_repo_head {
-	local repo=$1
-	local ref=$2
-	curl -sL https://api.github.com/repos/$repo/git/$ref | grep -Eo '[a-f0-9]{40}' | head -n 1
-}
-
-function get_github_reponame {
-	local repo="$repos/$1"
-	local remote_url=$(cd $repo; git config remote.origin.url)
-	
-	if [[ $remote_url =~ github.com ]]; then
-		printf -- $remote_url | sed -E 's#.*github\.com.([^:/]+)/([^/.]+)(\.git)?$#\1/\2#'
-	fi
 }

--- a/utils/help.sh
+++ b/utils/help.sh
@@ -31,7 +31,7 @@ cat <<EOM
   $0 generate PATH      # generate a homeshick-ready git repo at PATH
   $0 help [TASK]        # Describe available tasks or one specific task
   $0 list               # List cloned castles
-  $0 updates            # Check all repositories for updates (github only)
+  $0 updates            # Check all repositories for updates
   $0 pull NAME          # Update the specified castle
   $0 symlink NAME       # Symlinks all dotfiles from the specified castle
   $0 track FILE CASTLE  # add a file to a castle


### PR DESCRIPTION
Switched from GitHub API to `git ls-remote` so that private repos and non-GH repos also work with the `updates` command.

Why? I consider my dotfiles to be a bit too private for global visibility through GH, but would still like to use all the functionality.
