### PR TITLE
Added support for BSD style systems.

### DIFF
--- a/utils/git.sh
+++ b/utils/git.sh
@@ -162,7 +162,9 @@ function pull_outdated {
 		# No matter if we are going to pull the castles or not
 		# we reset the outdated ones by touching FETCH_HEAD
 		if [[ -e "$fetch_head" ]]; then
-			local time_diff=$[$(date +%s)-$(stat -c %Y "$fetch_head")]
+			local last_mod=$(stat -c %Y "$fetch_head" 2> /dev/null || stat -f %m "$fetch_head" 2> /dev/null)
+			local time_now=$(date +%s)
+			local time_diff=$((time_now-last_mod))
 			if [[ $time_diff -gt $threshhold ]]; then
 				outdated_castles+=($castle)
 				! $BATCH && touch "$fetch_head"


### PR DESCRIPTION
The stat command on BSD style systems, doesn't have the -c switch used in utils/git.sh, so made a feature detection on the stat command, to determine which switch to use.

I also had a problem with the $[$()-$()] syntax that was used in the to determine time_diff of the modifed time on the FETCH_HEAD. So I fixed that as well.

Using FreeBSD 9.1.
Tested the changes doesn't break homeshick on a Linux system (Debian squeeze)
