### PR TITLE
Changed git:// to https:// to allow for updates on cloned machine + Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ You can also run a subcommand on all castles by not specifying any arguments.
 ## Commands ##
 
 ### link ###
-You have already seen the first command in the installation procedure: `link`.
 This command symlinks all files that reside in the `home` folders of your castles into your home folder.
 You will be prompted if there are any files or folders that would be overwritten.
 
@@ -74,7 +73,8 @@ You can see your installed castles by running the `list` command.
 
 ### track ###
 If you have a new dotfile that you want to put in one of your castles, you can ask
-homeshick to do the moving and symlinking for you.
+homeshick to do the moving and symlinking for you. Note that this does not add it
+to your castle's git repository.
 To track your `.bashrc` and `.zshrc` in your `dotfiles` castle
 run `homeshick track dotfiles .bashrc .zshrc`.
 
@@ -88,6 +88,8 @@ This goes very well with your rc scripts (check out the [tutorial](#tutorial) fo
 
 
 ## Tutorial ##
+
+### Original machine ###
 
 In the installation you added an alias to the `.bashrc` file with
 ```
@@ -128,6 +130,19 @@ You can put this into your `.bashrc` file to run the check everytime you start u
 *(The `--quiet` flag makes sure your terminal is not spammed with status info on every startup)*
 
 If you prefer to update your dotfiles every other day, simply run `homeshick refresh 2` instead.
+
+### Updating your castle ###
+To make changes to one of your castles you simply use git. For example,
+if you want to update your `dotfiles` castle from a machine which 
+has it: 
+
+```
+cd $HOME/.homesick/repos/dotfiles
+git add <newdotfile>
+git commit -m "Added <newdotfile>"
+git push origin master
+homeshick link
+```
 
 ## Automatic deployment ##
 After having launched ec2 instances a lot, I got tired of installing zsh, tmux etc.

--- a/utils/git.sh
+++ b/utils/git.sh
@@ -15,7 +15,7 @@ function clone {
 	local git_repo=$1
 	local repo_path="$repos/$(parse_url $git_repo)"
 	if [[ $git_repo =~ ^([A-Za-z_-]+\/[A-Za-z_-]+)$ ]]; then
-		git_repo="git://github.com/$git_repo.git"
+		git_repo="https://github.com/$git_repo.git"
 	fi
 	pending 'clone' $git_repo
 	test -e $repo_path && err $EX_ERR "$repo_path already exists"

--- a/utils/help.sh
+++ b/utils/help.sh
@@ -4,7 +4,7 @@ function help {
 		extended_help $1
 		exit $EX_SUCCESS
 	fi
-printf "home${bldblu}s${txtdef}hick uses git in concert with symlinks to track your precious dotfiles.
+printf "homes${bldblu}h${txtdef}ick uses git in concert with symlinks to track your precious dotfiles.
 
  Usage: homeshick [options] TASK
 


### PR DESCRIPTION
It might be me, but after I cloned a castle to one of my machines, made some changes to a file and tried to push it back to my repo, I got `You can't push to git://github.com/fenekku/dotfiles.git`. I think it's because `homeshick clone` uses `git://` to get the repo instead of `https://` and github.com doesn't seem to allow pushes via `git://`. So I changed the protocol to https. Now I didn't see any other people mentioning this issue so I might very well be missing something obvious here :) .

This not withstanding, I also updated the documentation to make the updating of one's castle files clearer: issue #30 and #31 hint at some confusion there. Maybe this makes it clearer.

I've also changed the blue s to a blue h in the help.sh. You meant to emphasize the difference between homesick and homes_h_ick right ;) ? 
