### PR TITLE
fix link command for symlink directory 

### DIFF
--- a/test/link.sh
+++ b/test/link.sh
@@ -3,6 +3,7 @@
 function oneTimeSetUp() {
 	$HOMESHICK_BIN --batch clone $REPO_FIXTURES/rc-files > /dev/null
 	$HOMESHICK_BIN --batch clone $REPO_FIXTURES/dotfiles > /dev/null
+	$HOMESHICK_BIN --batch clone $REPO_FIXTURES/module-files > /dev/null
 }
 
 function testLinking() {
@@ -33,6 +34,12 @@ EOF
 	assertTrue "'link' did not symlink the .config/bar.dir directory" "[ -f $HOME/.config/bar.dir ]"
 }
 
+function testSymlinkDirectory() {
+	assertFalse "The .my_module existed before symlinking" "[ -e $HOME/.my_module ]"
+	$HOMESHICK_BIN --batch link module-files > /dev/null
+	assertTrue "'link' did not symlink the .my_module symlink" "[ -L $HOME/.my_module ]"
+}
+
 function testLegacySymlinks() {
 	assertTrue "known_hosts file does not exist" "[ -e $HOME/.ssh/known_hosts ]"
 	rm -rf "$HOME/.ssh"
@@ -48,6 +55,7 @@ function testLegacySymlinks() {
 function oneTimeTearDown() {
 	rm -rf "$HOMESICK/repos/rc-files"
 	rm -rf "$HOMESICK/repos/dotfiles"
+	rm -rf "$HOMESICK/repos/module-files"
 	find "$HOME" -mindepth 1 -not -path "${HOMESICK}*" -delete
 }
 

--- a/test/repo_fixtures.sh
+++ b/test/repo_fixtures.sh
@@ -24,6 +24,36 @@ EOF
 		git commit -m '.bashrc file for my new rc-files repo'
 	) > /dev/null
 
+	local my_module="$REPO_FIXTURES/my_module"
+	(
+		git init $my_module
+		cd $my_module
+		git config user.name $git_username
+		git config user.email $git_useremail
+		cat > module_foo.conf <<EOF
+# my module file
+EOF
+		git add module_foo.conf
+		git commit -m 'module_foo file for new my_module repo'
+	) > /dev/null
+
+	local module_files="$REPO_FIXTURES/module-files"
+	(
+		git init $module_files
+		cd $module_files
+		git config user.name $git_username
+		git config user.email $git_useremail
+
+		git submodule add $my_module
+		git commit -m 'my_module (git submodule) added for my new module-files repo'
+
+		mkdir home
+		cd home
+		ln -s ../my_module .my_module
+		git add .my_module
+		git commit -m 'Files added for my new module-files repo'
+	) > /dev/null
+
 	local dotfiles="$REPO_FIXTURES/dotfiles"
 	(
 		git init $dotfiles

--- a/utils/fs.sh
+++ b/utils/fs.sh
@@ -40,7 +40,7 @@ function symlink {
 			rm -rf "$HOME/$file"
 		fi
 
-		if [[ -d $repo/home/$file ]]; then
+		if [[ -d $repo/home/$file && ! -L $repo/home/$file ]]; then
 			pending $bldblu 'directory' $file
 			mkdir $HOME/$file
 		else


### PR DESCRIPTION
When there is a symlink directory under my castle's home directory, `homeshick link my_castle` command failds to create a symlink.(It just creates an empty directory.)

In pull request, I added a symlink directory check. So that, the else clause, which is for symlink directory, get called appropriately.
