### PR TITLE
First stab at storm command

### DIFF
--- a/home/.homeshick
+++ b/home/.homeshick
@@ -11,6 +11,7 @@ source $homeshick/utils/fs.sh
 source $homeshick/utils/git.sh
 source $homeshick/utils/help.sh
 source $homeshick/utils/exit_status.sh
+source $homeshick/utils/storm.sh
 
 exit_status=$EX_SUCCESS
 
@@ -55,7 +56,7 @@ done
 [[ $# -gt 0 ]] || cmd="help"
 
 # Get the subcommand
-valid_commands=(clone generate list check updates refresh pull symlink link track help)
+valid_commands=(clone generate list check updates refresh pull storm symlink link track help)
 if [[ ! $cmd ]]; then
 	if [[ " ${valid_commands[*]} " =~ " $1 " ]]; then
 		cmd=$1
@@ -87,7 +88,7 @@ while [[ $# -gt 0 ]]; do
 	fi
 
 	case $cmd in
-		clone | generate | check | updates | pull | symlink | link)
+		clone | generate | check | updates | pull | storm | symlink | link)
 			params+=($1)
 			shift; continue ;;
 		refresh)
@@ -139,6 +140,7 @@ case $cmd in
 			clone)   symlink_cloned_files ${params[*]}      ;;
 			refresh) pull_outdated $threshhold ${params[*]} ;;
 			pull)    symlink_new_files ${params[*]}         ;;
+			storm)   storm ${params[*]}                     ;;
 		esac
 		result=$?
 		if [[ $exit_status == 0 && $result != 0 ]]; then

--- a/utils/help.sh
+++ b/utils/help.sh
@@ -16,6 +16,7 @@ printf "homes${bldblu}h${txtdef}ick uses git in concert with symlinks to track y
   homeshick refresh [DAYS] [CASTLE..] # Check if a castle needs refreshing
   homeshick pull [CASTLE..]           # Update a castle
   homeshick link [CASTLE..]           # Symlinks all dotfiles from a castle
+  homeshick storm CASTLE..            # Opens a subshell inside of the castle
   homeshick track CASTLE FILE..       # Add a file to a castle
   homeshick help [TASK]               # Show usage of a task
 
@@ -71,6 +72,10 @@ function extended_help {
 		link|symlink)
       printf "Symlinks all dotfiles from a castle\n"
       printf "Usage:\n  homeshick $1 [CASTLE..]"
+      ;;
+		storm)
+      printf "Opens a subshell inside of the castle\n"
+      printf "Usage:\n  homeshick $1 CASTLE"
       ;;
 		track)
       printf "Adds a file to a castle.\n"

--- a/utils/storm.sh
+++ b/utils/storm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function storm {
+	[[ -z "$1" ]] && help storm
+	CASTLE="$HOME/.homesick/repos/$1"
+	local castle=$1
+	castle_exists storm $castle
+	local repo="$repos/$castle"
+	export PS1="(Castle:`basename \"$castle\"`)\n$PS1"
+	cd $repo
+	$SHELL
+	return $EX_SUCCESS
+}


### PR DESCRIPTION
New storm command opens a subshell in the specified CASTLE

Prompt changing will probably need some more work for debian/ubuntu/etc. I developed this on OS X.

We can alias cd to this, but it's important to note that we're not actually changing the pwd of the parent shell.
