### PR TITLE
Fix branch name extraction

### DIFF
--- a/utils/git.sh
+++ b/utils/git.sh
@@ -83,7 +83,7 @@ function pull {
 function list {
 	for reponame in $(list_castle_names); do
 		local ref=$(cd $repos/$reponame; git symbolic-ref HEAD 2>/dev/null)
-		local branch=$(basename $ref 2>/dev/null)
+		local branch=${ref#refs/heads/}
 		local remote_name=$(cd $repos/$reponame; git config branch.$branch.remote 2>/dev/null)
 		local remote_url=$(cd $repos/$reponame; git config remote.$remote_name.url 2>/dev/null)
 		info $reponame $remote_url
@@ -108,7 +108,7 @@ function check {
 	castle_exists 'check' $castle
 
 	local ref=$(cd $repo; git symbolic-ref HEAD 2>/dev/null)
-	local branch=$(basename $ref 2>/dev/null)
+	local branch=${ref#refs/heads/}
 	local remote_name=$(cd $repo; git config branch.$branch.remote 2>/dev/null)
 	local remote_url=$(cd $repo; git config remote.$remote_name.url 2>/dev/null)
 	local remote_head=$(git ls-remote -q --heads "$remote_url" "$branch" 2>/dev/null | cut -f 1)


### PR DESCRIPTION
Instead of using basename, just remove the "refs/heads/" prefix.
With basename, branch names like "foo/bar" become just "bar".
