### PR TITLE
homeshick-completion.bash: Fix filename completion behavior

### DIFF
--- a/completions/homeshick-completion.bash
+++ b/completions/homeshick-completion.bash
@@ -52,9 +52,15 @@ _homeshick_complete_castles()
 
 _homeshick_complete()
 {
-    COMPREPLY=()
+    # The comments at the bottom of the file explain what's going on here.
+    if [ $_HOMESHICK_HAS_COMPOPT ]; then
+        compopt +o default +o nospace
+        COMPREPLY=()
+    else
+        COMPREPLY=('')
+    fi
 
-    local -r cmds="
+    local -r cmds='
         cd
         clone
         generate
@@ -67,9 +73,10 @@ _homeshick_complete()
         help
         symlink
         updates
-    "
-    local -r short_opts="-q      -s     -f      -b"
-    local -r long_opts="--quiet --skip --force --batch"
+    '
+    local -r short_opts='-q      -s     -f      -b'
+    local -r long_opts='--quiet --skip --force --batch'
+    local -r protocols='file ftp ftps git http https rsync ssh'
 
     # Scan through the command line and find the homeshick command
     # (if present), as well as its expected position.
@@ -101,7 +108,7 @@ _homeshick_complete()
                 COMPREPLY=($(compgen -W "$short_opts" -- $cur))
                 ;;
             *)
-                COMPREPLY=() # We should never get here.
+                # Skip completion; we should never get here.
                 ;;
         esac
     elif (( $COMP_CWORD == $cmd_index )); then
@@ -121,9 +128,12 @@ _homeshick_complete()
                 fi
                 ;;
             refresh)
-                # Skip completion of the DAYS argument, but offer castle name
+                # Offer a numerical completion for DAYS (mostly as a reminder
+                # that this argument should be a number), then castle name
                 # completions after that.
-                if (( $COMP_CWORD > $cmd_index + 1 )); then
+                if (( $COMP_CWORD == $cmd_index + 1 )); then
+                    COMPREPLY=({0..9})
+                else
                     _homeshick_complete_castles "$cur"
                 fi
                 ;;
@@ -133,7 +143,16 @@ _homeshick_complete()
                 if (( $COMP_CWORD == $cmd_index + 1 )); then
                     _homeshick_complete_castles "$cur"
                 else
-                    COMPREPLY=($(compgen -f -- "$cur"))
+                    [ $_HOMESHICK_HAS_COMPOPT ] && compopt -o default
+                    # Let the default Readline filename completion take over.
+                    COMPREPLY=()
+                fi
+                ;;
+            clone)
+                # Offer an initial protocol completion.
+                if (( $COMP_CWORD == $cmd_index + 1 )); then
+                    [ $_HOMESHICK_HAS_COMPOPT ] && compopt -o nospace
+                    COMPREPLY=($(compgen -W "$protocols" -S '://' -- "$cur"))
                 fi
                 ;;
             help)
@@ -142,11 +161,37 @@ _homeshick_complete()
                     COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
                 fi
                 ;;
-            *)  # clone | generate | <unknown_command>
-                # Skip completion of unknowable arguments.
+            *)
+                # Unknown command or unknowable argument.
                 ;;
         esac
     fi
 }
 
-complete -F _homeshick_complete homeshick
+# The behavior of 'compgen -f' is pretty bizarre, in that if there's a
+# directory 'foo', then compgen simply completes 'foo' and moves on, rather
+# than offering to complete names of files underneath 'foo', which is what
+# Bash (or Readline, actually) usually does.
+#
+# You can get the usual Readline filename completion behavior by doing
+# 'complete -o default -F <func>', in which case the Readline filename
+# completer is called if COMPREPLY=(). But this also means that you can no
+# longer deny completion with COMPREPLY=() -- now Readline will always offer
+# to complete a filename, even if this is inappropriate (e.g., the command
+# takes no further arguments).
+#
+# In Bash 4.0 and above, there's a way to work around this problem. These
+# versions have a 'compopt' builtin, which allows '-o default' to be enabled
+# or disabled as needed. The workaround, then, is to disable '-o default'
+# at the top of the completion function, and enable it as needed later on.
+#
+# For older Bash releases, there's a different workaround that doesn't work
+# quite as well, but is still better than nothing. This workaround is to
+# always enable '-o default' (which can't be disabled later), and then to use
+# COMPREPLY=('') to semi-deny completion. That is, pressing Tab will just add
+# space characters to the command line, rather than generating filenames.
+#
+if type compopt >/dev/null 2>&1; then
+    _HOMESHICK_HAS_COMPOPT=1
+fi
+complete -o default -F _homeshick_complete homeshick


### PR DESCRIPTION
Files under directories were not being offered as completions.

Also, added some argument completions for the 'clone' and 'refresh' commands,
and did some minor cleanup.
