### PR TITLE
added install and update support for homeshick

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -55,7 +55,7 @@ done
 [[ $# -gt 0 ]] || cmd="help"
 
 # Get the subcommand
-valid_commands=(cd clone generate list check updates refresh pull symlink link track help)
+valid_commands=(cd clone generate list check updates refresh pull symlink link track help install update)
 if [[ ! $cmd ]]; then
 	if [[ " ${valid_commands[*]} " =~ " $1 " ]]; then
 		cmd=$1
@@ -87,7 +87,7 @@ while [[ $# -gt 0 ]]; do
 	fi
 
 	case $cmd in
-		cd | clone | generate | check | updates | pull | symlink | link)
+		cd | clone | generate | check | updates | pull | symlink | link |install | update)
 			params+=("$1")
 			shift; continue ;;
 		refresh)
@@ -107,7 +107,7 @@ done
 # If no additional arguments are given, run the subcommand for every castle
 if [[ ! $params ]]; then
 	case $cmd in
-		check | updates | refresh | pull | symlink | link)
+		check | updates | refresh | pull | symlink | link | install | update)
 			while IFS= read -d $'\n' -r name ; do
 				params+=("$name")
 			done < <(list_castle_names) ;;
@@ -133,6 +133,8 @@ case $cmd in
 				pull)          pull "$param"                ;;
 				symlink|link)  symlink "$param"             ;;
 				track)         track "$castle" "$param"     ;;
+				install)	     install "$param" 	;;
+				update)	update "$param"	;;
 			esac
 			result=$?
 			if [[ $exit_status == 0 && $result != 0 ]]; then
@@ -140,9 +142,9 @@ case $cmd in
 			fi
 		done
 		case $cmd in
-			clone)   symlink_cloned_files ${params[*]}      ;;
-			refresh) pull_outdated $threshhold ${params[*]} ;;
-			pull)    symlink_new_files ${params[*]}         ;;
+			clone)   install_cloned_castle ${params[*]} ; symlink_cloned_files ${params[*]}     ;;
+			refresh) update_updated_castle ${params[*]} ; pull_outdated $threshhold ${params[*]} 	;;
+			pull)   iupdate_updated_castle ${params[*]} ;  symlink_new_files ${params[*]} ;         ;;
 		esac
 		result=$?
 		if [[ $exit_status == 0 && $result != 0 ]]; then

--- a/test/repo_fixtures.sh
+++ b/test/repo_fixtures.sh
@@ -103,18 +103,18 @@ EOF
 
 		mkdir -p .config/foo.conf
 		cat > .config/foo.conf/a.conf <<EOF
-#I am just a regular config file 
+#I am just a regular config file
 [A]
 LikesIceCream=True
 EOF
 		cat > .config/bar.dir <<EOF
-#And I am just a regular config file with a weird name 
+#And I am just a regular config file with a weird name
 [B]
 LikesCucumber=False
 EOF
 		git add .config
 		git commit -m 'Files added for my new dotfiles repo'
-		
+
 		mkdir .ssh
 		cat > .ssh/known_hosts <<EOF
 github.com,207.97.227.239 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
@@ -167,5 +167,17 @@ EOF
 
 		git add .repowithspacesfile
 		git commit -m 'Add file to repo with spaces in name'
+	) > /dev/null
+
+	local install_update="$REPO_FIXTURES/install_update"
+	(
+		git init $install_update
+		cd $install_update
+		git config user.name $git_username
+		git config user.email $git_useremail
+		echo "#!/bin/bash" > install
+		echo "cp install update" >> install
+		git add install
+		git commit -m 'Add file to repo with install script'
 	) > /dev/null
 }

--- a/test/suites/install_update.sh
+++ b/test/suites/install_update.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+function oneTimeSetUp() {
+	source $HOMESHICK_FN_SRC
+	$HOMESHICK_FN --batch clone $REPO_FIXTURES/rc-files > /dev/null
+        	$HOMESHICK_FN --batch clone $REPO_FIXTURES/dotfiles > /dev/null
+        	$HOMESHICK_FN --batch clone $REPO_FIXTURES/module-files > /dev/null
+        	$HOMESHICK_FN --batch clone "$REPO_FIXTURES/repo with spaces in name" > /dev/null
+	$HOMESHICK_FN --batch clone $REPO_FIXTURES/install_update > /dev/null
+}
+
+function oneTimeTearDown() {
+	rm -rf "$HOMESICK/repos/rc-files"
+        	rm -rf "$HOMESICK/repos/dotfiles"
+        	rm -rf "$HOMESICK/repos/module-files"
+        	rm -rf "$HOMESICK/repos/repo with spaces in name"
+	rm -rf "$HOMESICK/repos/install_update"
+}
+
+function tearDown() {
+	find "$HOME" -mindepth 1 -not -path "${HOMESICK}*" -delete
+}
+
+function testInstall() {
+	$HOMESHICK_FN --batch install install_update > /dev/null
+	assertTrue "\`install' created update file" "[ -f $REPO_FIXTURES/install_update/update ]"
+}
+
+function testUpdate() {
+	echo "cp update finished" >> $REPO_FIXTURES/install_update/update
+	$HOMESHICK_FN --batch update install_update > /dev/null
+	assertTrue "\`update' created finished file" "[ -f $REPO_FIXTURES/install_update/finished ]"
+}
+
+source $SHUNIT2

--- a/utils/git.sh
+++ b/utils/git.sh
@@ -274,7 +274,99 @@ function ask_symlink {
 	return $EX_SUCCESS
 }
 
-# Snatched from http://stackoverflow.com/questions/4023830/bash-how-compare-two-strings-in-version-format 
+function install_cloned_castle {
+	local cloned_castles=()
+	while [[ $# -gt 0 ]]; do
+		local git_repo=$(git_shorthand "$1")
+		local castle=$(repo_basename "$git_repo")
+		shift
+		local repo="$repos/$castle"
+		if [ ! -f $repo/install ]; then
+			continue;
+		fi
+		cloned_castles+=("$castle")
+	done
+	ask_install ${cloned_castles[*]}
+	return $EX_SUCCESS
+}
+
+function update_updated_castle {
+	local updated_castles=()
+	while [[ $# -gt 0 ]]; do
+		local castle=$1
+		shift
+		local repo="$repos/$castle"
+		if [ -f $repo/update ]; then
+			updated_castles+=("$castle");
+		fi
+	done
+	ask_update ${updated_castles[*]}
+	return $EX_SUCCESS
+}
+
+function ask_update {
+	if [[ $# -gt 0 ]]; then
+		if [[ $# == 1 ]]; then
+			msg="The castle $1 can be updated."
+		else
+			OIFS=$IFS
+			IFS=,
+			msg="The castles $* can be updated."
+			IFS=$OIFS
+		fi
+		prompt_no 'updates' "$msg" 'update?'
+		if [[ $? = 0 ]]; then
+			for castle in $*; do
+				update "$castle"
+			done
+		fi
+	fi
+	return $EX_SUCCESS
+}
+
+function ask_install {
+	if [[ $# -gt 0 ]]; then
+		if [[ $# == 1 ]]; then
+			msg="The castle $1 can be installed."
+		else
+			OIFS=$IFS
+			IFS=,
+			msg="The castles $* can be installed."
+			IFS=$OIFS
+		fi
+		prompt_no 'NEW ' "$msg" 'install?'
+		if [[ $? = 0 ]]; then
+			for castle in $*; do
+				install "$castle"
+			done
+		fi
+	fi
+	return $EX_SUCCESS
+}
+
+function update {
+	local castle=$1
+        	castle_exists "$castle"
+        	local repo="$repos/$castle"
+        	if [ -f $repo/update ]; then
+        		$repo/update;
+        	else
+        		echo $castle " doesn't contain an update file!";
+        	fi
+}
+
+function install {
+	local castle=$1
+        	castle_exists "$castle"
+        	local repo="$repos/$castle"
+        	if [ -f $repo/install ]; then
+        		$repo/install;
+        	else
+        		echo $castle " doesn't contain an install file";
+        	fi
+}
+
+# Snatched from http://stackoverflow.com/questions/4023830/bash-how-compare-two-strings-in-version-format
 function version_compare {
 	if [[ $1 == $2 ]]; then
 		return 0

--- a/utils/help.sh
+++ b/utils/help.sh
@@ -19,6 +19,8 @@ printf "homes${bldblu}h${txtdef}ick uses git in concert with symlinks to track y
   homeshick link [CASTLE..]           # Symlinks all dotfiles from a castle
   homeshick track CASTLE FILE..       # Add a file to a castle
   homeshick help [TASK]               # Show usage of a task
+  homeshick install CASTLE            # Install the castle
+  homeshick update CASTLE             # Update the castle
 
  Aliases:
   symlink # Alias to link
@@ -87,6 +89,15 @@ function extended_help {
       printf "Shows usage of a task\n"
       printf "Usage:\n  homeshick help [TASK]"
       ;;
+              install)
+      printf "Installs the castle if the install file exists.\n"
+      printf "Usage:\n  homeshick install CASTLE"
+      ;;
+              update)
+      printf "Updates the castle if the update file exists.\n"
+      printf "Usage:\n  homeshick update CASTLE"
+      ;;
+
 		*)    help  ;;
 		esac
 	printf "\n\n"


### PR DESCRIPTION
This pull requests implements the option to support an install and update file which can be executed either manually via homeshick install CASTLE or homeshick update CASTLE or automatically during clone, pull and refresh actions.

This allows to run scripts to make further changes which are not possible by symlinking alone.

Question: Would it make sense to move the install and update invokement for clone, pull and refresh in front of the original functions?
