### PR TITLE
Fixes #92: symlinked items don't preserve file permissions

### DIFF
--- a/test/helper.bash
+++ b/test/helper.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "$BATS_TEST_DIRNAME/../../utils/fs.sh"
+
 function export_env_vars {
 	if [[ -n $BATS_TEST_DIRNAME ]]; then
 		export TESTDIR=$(cd "${BATS_TEST_DIRNAME}/.."; printf "$(pwd)")

--- a/test/suites/link.bats
+++ b/test/suites/link.bats
@@ -114,3 +114,15 @@ newline"
 	is_symlink $HOMESICK/repos/rc-files/home/filename $HOME/filename
 	is_symlink newline $HOME/newline
 }
+
+@test 'link should have same access permissions as file' {
+	castle 'rc-files'
+	file="$HOMESICK/repos/rc-files/home/filename"
+	touch $file
+	chmod 0600 $file
+	$HOMESHICK_FN --batch link rc-files
+	is_symlink $file $HOME/filename
+	file_octal=$(octal_access $file)
+	link_octal=$(octal_access $HOME/filename)
+	[ $link_octal = $file_octal ]
+}

--- a/test/suites/misc.bats
+++ b/test/suites/misc.bats
@@ -6,3 +6,15 @@ load ../helper
 	run $HOMESHICK_FN commandthatdoesnexist
 	[ $status -eq 64 ] # EX_USAGE
 }
+
+@test 'umask should not change after linking a file' {
+	orig_umask=$(umask)
+
+	castle 'rc-files'
+	file="$HOMESICK/repos/rc-files/home/filename"
+	touch $file
+	chmod 0600 $file
+	$HOMESHICK_FN --batch link rc-files
+
+	[ $orig_umask = $(umask) ]
+}

--- a/test/suites/track.bats
+++ b/test/suites/track.bats
@@ -207,3 +207,19 @@ EOF
 	[ ! -e $HOMESICK/repos/rc-files/home/.folder/ignored.swp ]
 	[ -e $HOMESICK/repos/rc-files/home/.folder ]
 }
+
+@test 'track should create link with same access permissions as file' {
+	castle 'rc-files'
+	file=$HOMESICK/repos/rc-files/home/.zshrc
+	link=$HOME/.zshrc
+	cat > $link <<EOF
+homeshick --batch refresh
+EOF
+	chmod 0600 $link
+	$HOMESHICK_FN track rc-files $HOME/.zshrc
+
+	is_symlink $file $link
+	file_octal=$(octal_access $file)
+	link_octal=$(octal_access $link)
+	[ $link_octal = $file_octal ]
+}


### PR DESCRIPTION
Let me know what you think. I'm looking to learn, so feel free to give me any suggestions you may have.

So you know, I couldn't chmod a symbolic link so I had to use umask to create the link with the correct permissions. Maybe I should add a comment to the code. I'm not sure if that is general knowledge.

I added a line to source the fs.sh file in the bats helper. I did so in order to gain access to the `octal_access` function in my tests. Let me know if there is a better way to do that.

Something else to note, I didn't handle the scenario where a file's access changes in git and the file is already linked. Should I add that to this PR or open a new issue?
