### PR TITLE
This resolves #95 : Only symlink files that are tracked by git

### DIFF
--- a/test/helper.bash
+++ b/test/helper.bash
@@ -145,3 +145,14 @@ function mock_git_version {
 	# The function needs to be exported for it to work in child processes
 	export -f git
 }
+
+function commit_repo_state {
+	local repo=$1
+	(
+		cd $repo
+		git config user.name "Homeshick user"
+		git config user.email "homeshick@example.com"
+		git add -A
+		git commit -m "Commiting Repo State from test helper.bash."
+	)
+}

--- a/test/suites/link.bats
+++ b/test/suites/link.bats
@@ -108,9 +108,21 @@ EOF
 	castle 'rc-files'
 	touch "$HOMESICK/repos/rc-files/home/filename
 newline"
+	commit_repo_state $HOMESICK/repos/rc-files
 	$HOMESHICK_FN --batch link rc-files
-	[ -L "$HOME/filename" ]
-	[ -L "$HOME/newline" ]
-	is_symlink $HOMESICK/repos/rc-files/home/filename $HOME/filename
-	is_symlink newline $HOME/newline
+	[ -L "$HOME/\"filename" ]
+	[ -L "$HOME/newline\"" ]
+	is_symlink $HOMESICK/repos/rc-files/home/\"filename $HOME/\"filename
+	is_symlink $HOMESICK/repos/rc-files/home/newline\" $HOME/newline\"
+}
+
+@test 'files ignored by git should not be linked' {
+	castle 'dotfiles'
+	touch "$HOMESICK/repos/dotfiles/home/shouldBeIgnored.txt"
+	cat > $HOMESICK/repos/dotfiles/.gitignore <<EOF
+shouldBeIgnored.txt
+EOF
+	commit_repo_state $HOMESICK/repos/dotfiles
+	$HOMESHICK_FN --batch link dotfiles
+	[ ! -L "$HOME/shouldBeIgnored.txt" ]
 }

--- a/utils/fs.sh
+++ b/utils/fs.sh
@@ -11,9 +11,9 @@ function symlink {
 	fi
 	oldIFS=$IFS
 	IFS=$'\n'
-	for remote in $(find "$repo/home" -mindepth 1 -name .git -prune -o -print); do
+	for filename in $(get_repo_files $repo); do
+		remote="$repo/home/$filename"
 		IFS=$oldIFS
-		filename=${remote#$repo/home/}
 		local=$HOME/$filename
 
 		if [[ -e $local || -L $local ]]; then
@@ -134,6 +134,25 @@ function track {
 		success
 	done
 	return $EX_SUCCESS
+}
+
+function get_repo_files {
+	local repo=$1
+	local dirs=""
+	local files=""
+	for file in $(cd $repo/home && git ls-files); do
+		if [[ -n $dirs ]]; then
+			dirs="$dirs\n"
+		fi
+		dirs="$dirs${file%/*}"
+
+		if [[ -n $files ]]; then
+			files="$files\n"
+		fi
+		files="$files$file"
+	done;
+
+	echo "$(echo -e "$dirs\n$files" | sort | uniq)"
 }
 
 function castle_exists {


### PR DESCRIPTION
Besides adding a test for this feature, I also had to update some
existing tests slightly.

First I had to make sure that tests that modify their test repo, also
commit to that test repo. Otherwise the linking function wouldn't do
anything since git ignores files not added to the repo.

Secondly, I had to modify the 'fail when linking file with newline' test
to look for symlinks with double quotes since that is how they are
returned by `git ls-files` which brings up the point that we could now
support filenames with newlines in them. `git ls-files` wraps such
filenames in quotes like:

"subdir/filename_with\nnewline"

That being said I'm not sure of the usefulness of newlines in filenames.
