### PR TITLE
Speed-up symlinking of submodules

### DIFF
--- a/lib/commands/link.sh
+++ b/lib/commands/link.sh
@@ -85,9 +85,11 @@ function get_repo_files {
 			path=$(dirname $path)
 			paths="$prefix$path\n$paths"
 		done
-		for submodule in $(cd $dir; git submodule --quiet foreach 'printf "%s\n" "$path"'); do
-			paths="$(get_repo_files $dir $submodule)\n$paths"
-		done
 	done
+
+	for submodule in $(cd $dir; git submodule --quiet foreach 'printf "%s\n" "$path"'); do
+		paths="$(get_repo_files $dir $submodule)\n$paths"
+	done
+
 	printf "$paths" | sort | uniq
 }


### PR DESCRIPTION
Fixes #108.

Your version worked, but it was very slow since there was lots of repeated work (adding every file in every submodule for every file in the home).
I didn't use `git submodule`, since git doesn't track folders if a folder appears in `git ls-files` it must be a submodule (I think). The tests all pass.

Let me know what you think.
