### PR TITLE
Make homeshich.sh position-independent

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -2,9 +2,6 @@
 
 repos="$HOME/.homesick/repos"
 homeshick="${HOMESHICK_DIR:-$repos/homeshick}"
-# It's either this^ or the one below:
-# scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# The install script however symlinks us. So $0 changes.
 
 # Include all helper functions. We will include the required command function later on.
 source "$homeshick/lib/exit_status.sh"

--- a/bin/homeshick
+++ b/bin/homeshick
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 repos="$HOME/.homesick/repos"
-homeshick="$repos/homeshick"
+homeshick="${HOMESHICK_DIR:-$repos/homeshick}"
 # It's either this^ or the one below:
 # scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # The install script however symlinks us. So $0 changes.

--- a/homeshick.fish
+++ b/homeshick.fish
@@ -7,6 +7,6 @@ function homeshick
 	if test \( (count $argv) = 2 -a $argv[1] = "cd" \)
 		cd "$HOME/.homesick/repos/$argv[2]"
 	else
-		eval $HOME/.homesick/repos/homeshick/bin/homeshick $argv
+		eval env HOMESHICK_DIR=( dirname ( status -f )) $HOME/.homesick/repos/homeshick/bin/homeshick $argv
 	end
 end

--- a/homeshick.sh
+++ b/homeshick.sh
@@ -1,12 +1,15 @@
 # This script should be sourced in the context of your shell like so:
-# source $HOME/.homeshick/repos/.homeshick/homeshick.sh
+# source <path>/homeshick.sh
 # Once the homeshick() function is defined, you can type
 # "homeshick cd CASTLE" to enter a castle.
 
-function homeshick() {
-	if [ "$1" = "cd" ] && [ -n "$2" ]; then
-		cd "$HOME/.homesick/repos/$2"
+__DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+eval "function homeshick() {
+	if [ \"\$1\" = \"cd\" ] && [ -n \"\$2\" ]; then
+		cd \"\$HOME/.homesick/repos/\$2\"
 	else
-		$HOME/.homesick/repos/homeshick/bin/homeshick "$@"
+		HOMESHICK_DIR=\"$__DIR\" \"$__DIR/bin/homeshick\" \"\$@\"
 	fi
-}
+}"
+unset __DIR
+

--- a/homeshick.sh
+++ b/homeshick.sh
@@ -1,5 +1,5 @@
 # This script should be sourced in the context of your shell like so:
-# source <path>/homeshick.sh
+# source homeshick.sh
 # Once the homeshick() function is defined, you can type
 # "homeshick cd CASTLE" to enter a castle.
 


### PR DESCRIPTION
The current implementation of `homeshick.sh` contains a hard-coded path to the installation location of homeshick. This patch makes homeshick position-independent by computing the actual installation location at the time `homeshick.sh` is sourced (e.g., by `.bashrc`).

Users should never notice any difference if they install homeshick as described in the wiki. Hence, there are no specific tests to ensure the change works for arbitrary installation locations, but all existing tests show that it works for the default location.