### PR TITLE
HOMESHICK_DIR defines location of homeshick

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
 repos="$HOME/.homesick/repos"
-homeshick="$repos/homeshick"
-# It's either this^ or the one below:
-# scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# The install script however symlinks us. So $0 changes.
-
 # Include all helper functions. We will include the required command function later on.
+homeshick=${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}
 source "$homeshick/lib/exit_status.sh"
 source "$homeshick/lib/fs.sh"
 source "$homeshick/lib/git.sh"
@@ -126,9 +122,9 @@ fi
 # Include the file that implements the invoked command
 case $cmd in
 	cd) ;;
-	symlink) source $homeshick/lib/commands/link.sh ;;
-	updates) source $homeshick/lib/commands/check.sh ;;
-	*)       source $homeshick/lib/commands/$cmd.sh ;;
+	symlink) source "$homeshick/lib/commands/link.sh" ;;
+	updates) source "$homeshick/lib/commands/check.sh" ;;
+	*)       source "$homeshick/lib/commands/$cmd.sh" ;;
 esac
 
 case $cmd in

--- a/bin/homeshick.csh
+++ b/bin/homeshick.csh
@@ -9,5 +9,9 @@ if ( "$1" == "cd" && "x$2" != "x" ) then
         cd "$HOME/.homesick/repos/$2"
     endif
 else
-    $HOME/.homesick/repos/homeshick/bin/homeshick $*
+    if ( $?HOMESHICK_DIR ) then
+        $HOMESHICK_DIR/bin/homeshick $*
+    else
+        $HOME/.homesick/repos/homeshick/bin/homeshick $*
+    endif
 endif

--- a/homeshick.fish
+++ b/homeshick.fish
@@ -1,5 +1,5 @@
 # This script should be sourced in the context of your shell like so:
-# source $HOME/.homeshick/repos/.homeshick/homeshick.fish
+# source $HOME/.homesick/repos/homeshick/homeshick.fish
 # Once the homeshick() function is defined, you can type
 # "homeshick cd CASTLE" to enter a castle.
 

--- a/homeshick.fish
+++ b/homeshick.fish
@@ -1,11 +1,13 @@
 # This script should be sourced in the context of your shell like so:
-# source $HOME/.homesick/repos/homeshick/homeshick.fish
+# source $HOME/.homeshick/repos/.homeshick/homeshick.fish
 # Once the homeshick() function is defined, you can type
 # "homeshick cd CASTLE" to enter a castle.
 
 function homeshick
 	if test \( (count $argv) = 2 -a $argv[1] = "cd" \)
 		cd "$HOME/.homesick/repos/$argv[2]"
+	else if set -q HOMESHICK_DIR 
+		eval $HOMESHICK_DIR/bin/homeshick $argv
 	else
 		eval $HOME/.homesick/repos/homeshick/bin/homeshick $argv
 	end

--- a/homeshick.sh
+++ b/homeshick.sh
@@ -7,6 +7,6 @@ function homeshick() {
 	if [ "$1" = "cd" ] && [ -n "$2" ]; then
 		cd "$HOME/.homesick/repos/$2"
 	else
-		$HOME/.homesick/repos/homeshick/bin/homeshick "$@"
+		"${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}/bin/homeshick" "$@"
 	fi
 }

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -47,6 +47,7 @@ function mk_structure {
 	local hs_repo=$HOMESICK/repos/homeshick
 	mkdir -p $hs_repo
 	ln -s $(cd "${TESTDIR}/.."; printf "$(pwd)")/homeshick.sh "${hs_repo}/homeshick.sh"
+	ln -s $(cd "${TESTDIR}/.."; printf "$(pwd)")/homeshick.fish "${hs_repo}/homeshick.fish"
 	ln -s $(cd "${TESTDIR}/../bin"; printf "$(pwd)") "${hs_repo}/bin"
 	ln -s $(cd "${TESTDIR}/../lib"; printf "$(pwd)") "${hs_repo}/lib"
 	ln -s $(cd "${TESTDIR}/../completions"; printf "$(pwd)") "${hs_repo}/completions"

--- a/test/suites/homeshick_dir.bats
+++ b/test/suites/homeshick_dir.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load ../helper
+
+@test 'bash with homeshick_dir override' {
+	castle 'dotfiles'
+	local result=$( HOMESHICK_DIR=$_TMPDIR/nowhere $HOMESHICK_FN 2>&1 >/dev/null )
+	echo "result=$result"
+	[[ "$result" =~ "/nowhere/" ]]
+}
+
+@test 'fish with homeshick_dir override' {
+	[ $(type -t fish) = "file" ] || skip "fish not installed"
+	cmd="source ${HOMESHICK_FN_SRC%.sh}.fish; set HOMESHICK_DIR \"$_TMPDIR/nowhere\"; $HOMESHICK_FN"
+	local result=$( fish <<< "$cmd" 2>&1 >/dev/null )
+	echo "result=$result"
+	[[ "$result" =~ "/nowhere/" ]]
+}
+
+@test 'csh with homeshick_dir override' {
+	[ $(type -t csh) = "file" ] || skip "csh not installed"
+	cmd="set HOMESHICK_DIR=/nowhere; source ${HOMESHICK_BIN}.csh"
+	local result=$( csh <<< "$cmd" 2>&1 >/dev/null )
+	echo "result=$result"
+	[[ "$result" =~ "/nowhere/" ]]
+}
+


### PR DESCRIPTION
The current implementation of homeshick contains hard-coded paths to the (default) installation location. This patch makes homeshick position-independent by allowing the user to specify an alternative installation location using the `HOMESHICK_DIR` environment variable.