### PR TITLE
Tests also have to observe HOMESHICK_DIR.

### DIFF
--- a/test/helper.bash
+++ b/test/helper.bash
@@ -46,11 +46,12 @@ function mk_structure {
 	mkdir "$REPO_FIXTURES" "$HOME" "$NOTHOME"
 	local hs_repo=$HOMESICK/repos/homeshick
 	mkdir -p $hs_repo
-	ln -s $(cd "${TESTDIR}/.."; printf "$(pwd)")/homeshick.sh "${hs_repo}/homeshick.sh"
-	ln -s $(cd "${TESTDIR}/.."; printf "$(pwd)")/homeshick.fish "${hs_repo}/homeshick.fish"
-	ln -s $(cd "${TESTDIR}/../bin"; printf "$(pwd)") "${hs_repo}/bin"
-	ln -s $(cd "${TESTDIR}/../lib"; printf "$(pwd)") "${hs_repo}/lib"
-	ln -s $(cd "${TESTDIR}/../completions"; printf "$(pwd)") "${hs_repo}/completions"
+	local hs_under_test=${HOMESHICK_DIR:-$(cd "${TESTDIR}/.."; printf "$(pwd)")}
+	ln -s "$hs_under_test/homeshick.sh" "${hs_repo}/homeshick.sh"
+	ln -s "$hs_under_test/homeshick.fish" "${hs_repo}/homeshick.fish"
+	ln -s "$hs_under_test/bin" "${hs_repo}/bin"
+	ln -s "$hs_under_test/lib" "${hs_repo}/lib"
+	ln -s "$hs_under_test/completions" "${hs_repo}/completions"
 }
 
 function rm_structure {

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -10,11 +10,12 @@ function export_env_vars {
 	export REPO_FIXTURES="${_TMPDIR}/repos"
 	export HOME="${_TMPDIR}/home"
 	export NOTHOME="${_TMPDIR}/nothome"
-
 	export HOMESICK="$HOME/.homesick"
+
 	export HOMESHICK_FN="homeshick"
-	export HOMESHICK_FN_SRC="$HOMESICK/repos/homeshick/homeshick.sh"
-	export HOMESHICK_BIN="$HOMESICK/repos/homeshick/bin/homeshick"
+	export HOMESHICK_DIR=${HOMESHICK_DIR:-$(dirname "${TESTDIR}")}
+	export HOMESHICK_FN_SRC="$HOMESHICK_DIR/homeshick.sh"
+	export HOMESHICK_BIN="$HOMESHICK_DIR/bin/homeshick"
 
 	# Check if expect is installed
 	run type expect >/dev/null 2>&1
@@ -44,14 +45,6 @@ function remove_coreutils_from_path {
 
 function mk_structure {
 	mkdir "$REPO_FIXTURES" "$HOME" "$NOTHOME"
-	local hs_repo=$HOMESICK/repos/homeshick
-	mkdir -p $hs_repo
-	local hs_under_test=${HOMESHICK_DIR:-$(cd "${TESTDIR}/.."; printf "$(pwd)")}
-	ln -s "$hs_under_test/homeshick.sh" "${hs_repo}/homeshick.sh"
-	ln -s "$hs_under_test/homeshick.fish" "${hs_repo}/homeshick.fish"
-	ln -s "$hs_under_test/bin" "${hs_repo}/bin"
-	ln -s "$hs_under_test/lib" "${hs_repo}/lib"
-	ln -s "$hs_under_test/completions" "${hs_repo}/completions"
 }
 
 function rm_structure {

--- a/test/suites/abs_path.bats
+++ b/test/suites/abs_path.bats
@@ -4,7 +4,7 @@ load ../helper
 
 function setup() {
 	setup_env
-	source $HOMESICK/repos/homeshick/lib/fs.sh
+	source $HOMESHICK_DIR/lib/fs.sh
 }
 
 @test 'test simple filepath' {

--- a/test/suites/git_url_basename.bats
+++ b/test/suites/git_url_basename.bats
@@ -4,7 +4,7 @@ load ../helper
 
 function setup() {
 	setup_env
-	source $HOMESICK/repos/homeshick/lib/commands/clone.sh
+	source $HOMESHICK_DIR/lib/commands/clone.sh
 }
 
 @test 'git url basename: git@... .git' {


### PR DESCRIPTION
This allows running detached tests (i.e., the test cases do not have to
be co-located with the homeshick instance under test), like this:
$ HOMESHICK_DIR=/usr/share/homeshick bats test/suites/

This PR is a follow-up to #138.