### PR TITLE
update quick install for csh homeshick alias to include trailing newline when appending to .cshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To invoke homeshick, source the `homeshick.sh` script from your rc-script:
 # from sh and its derivates (bash, zsh etc.) 
 printf '\nsource "$HOME/.homesick/repos/homeshick/homeshick.sh"' >> $HOME/.bashrc
 # csh and derivatives (i.e. tcsh)
-printf '\nalias homeshick source "$HOME/.homesick/repos/homeshick/bin/homeshick.csh"' >> $HOME/.cshrc
+printf '\nalias homeshick source "$HOME/.homesick/repos/homeshick/bin/homeshick.csh"\n' >> $HOME/.cshrc
 # fish shell
 echo \n'source "$HOME/.homesick/repos/homeshick/homeshick.fish"' >> "$HOME/.config/fish/config.fish"
 ```


### PR DESCRIPTION
update quick install for csh homeshick alias to include trailing newline when appending to .cshrc
because there is a long standing issue in csh and tcsh
that skips execution of last line in script if it does NOT end with newline