### PR TITLE
Fix fish completions on OSX

### DIFF
--- a/completions/homeshick.fish
+++ b/completions/homeshick.fish
@@ -4,7 +4,7 @@ function __fish_homeshick_strip_options
         return 1
     end
     for item in $cmd[2..-1]
-        if [ (expr substr $item 1 1) = "-" ]
+        if [ (echo $item | sed 's/^\(.\).*/\1/') = "-" ]
             continue
         end
         echo $item


### PR DESCRIPTION
Use sed instead of expr, because there is no substr in expr on OSX.