### PR TITLE
Make homeshick() dash-compatible

### DIFF
--- a/homeshick.sh
+++ b/homeshick.sh
@@ -3,7 +3,7 @@
 # Once the homeshick() function is defined, you can type
 # "homeshick cd CASTLE" to enter a castle.
 
-function homeshick() {
+homeshick () {
 	if [ "$1" = "cd" ] && [ -n "$2" ]; then
 		cd "$HOME/.homesick/repos/$2"
 	else


### PR DESCRIPTION
Hello,

I have written a simple script to update my castles, whose interpreter is /bin/sh. On most of my systems it was working fine, until I've tried Ubuntu where dash is used. There, when I am sourcing `homeshick.sh` in dash, I get this error:

 ```
6: /home/joko/.homesick/repos/homeshick/homeshick.sh: Syntax error: "(" unexpected
```

This commit fixes this error. I have tried it over bash and zsh successfully, as well, and it passed the testsuites.