### PR TITLE
Support customizable homesick directory

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-repos="$HOME/.homesick/repos"
+homeshick="${HOMESICK_DIR:-$HOME/.homesick}/repos/homeshick"
+repos="$HOMESICK_DIR/repos"
+
+
 # Include all helper functions. We will include the required command function later on.
-homeshick=${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}
 source "$homeshick/lib/exit_status.sh"
 source "$homeshick/lib/fs.sh"
 source "$homeshick/lib/git.sh"

--- a/homeshick.fish
+++ b/homeshick.fish
@@ -5,10 +5,14 @@
 
 function homeshick
 	if test \( (count $argv) = 2 -a $argv[1] = "cd" \)
-		cd "$HOME/.homesick/repos/$argv[2]"
+        	if set -q HOMESICK_DIR
+			cd "$HOMESICK_DIR/repos/$argv[2]"
+		else
+			cd "$HOME/.homesick/repos/$argv[2]"
+		end	
 	else if set -q HOMESHICK_DIR 
 		eval $HOMESHICK_DIR/bin/homeshick $argv
 	else
-		eval $HOME/.homesick/repos/homeshick/bin/homeshick $argv
+		eval $HOMESICK_DIR/repos/homeshick/bin/homeshick $argv
 	end
 end

--- a/homeshick.sh
+++ b/homeshick.sh
@@ -4,9 +4,10 @@
 # "homeshick cd CASTLE" to enter a castle.
 
 homeshick () {
+        repos="${HOMESICK_DIR:-$HOME/.homesick}/repos"
 	if [ "$1" = "cd" ] && [ -n "$2" ]; then
-		cd "$HOME/.homesick/repos/$2"
+		cd "$repos/$2"
 	else
-		"${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}/bin/homeshick" "$@"
+		"$repos/homeshick/bin/homeshick" "$@"
 	fi
 }


### PR DESCRIPTION
This adds the ability to support when homesick is installed to custom locations.

I keep mine in `~/.config/homesick`, with my repos being in `~/.config/homesick/repos`, which puts `~/.config/homesick/repos/homeshick`.