### PR TITLE
Remove debug output from pull.sh

### DIFF
--- a/lib/commands/pull.sh
+++ b/lib/commands/pull.sh
@@ -43,7 +43,6 @@ function symlink_new_files {
 		git_out=$(cd "$repo"; git diff --name-only --diff-filter=A HEAD@{$[$now-$T_START+1].seconds.ago} HEAD -- home 2>/dev/null | wc -l 2>&1)
 		[[ $? == 0 ]] || continue # Ignore errors, this operation is not mission critical
 		if [[ $git_out -gt 0 ]]; then
-			echo $git_out
 			updated_castles+=("$castle")
 		fi
 	done


### PR DESCRIPTION
A change in pull.sh has a debug line that probably shouldn't be there. It outputs a spurious "1" when pulling:

<pre>
fire@danton:~ $ homeshick pull vim
         pull vim
1
      updates The castle vim has new files.
     symlink? [yN] y
      symlink .vim/bundle/vim-git
</pre>