### PR TITLE
Make 'homeshick check' ls-remote call compatbile with git-1.7

### DIFF
--- a/lib/commands/check.sh
+++ b/lib/commands/check.sh
@@ -15,7 +15,7 @@ function check {
 	local remote_name=$(cd "$repo"; git config branch.$branch.remote 2>/dev/null)
 	local remote_url=$(cd "$repo"; git config remote.$remote_name.url 2>/dev/null)
 	# Get the HEAD of the current branch on the upstream remote
-	local remote_head=$(git ls-remote -q --heads "$remote_url" "$branch" 2>/dev/null | cut -f 1)
+	local remote_head=$(git ls-remote --heads "$remote_url" "$branch" 2>/dev/null | cut -f 1)
 	if [[ $remote_head ]]; then
 		local local_head=$(cd "$repo"; git rev-parse HEAD)
 		if [[ $remote_head == $local_head ]]; then


### PR DESCRIPTION
Turns out git 1.7... (1) doesn't support the -q option to ls-remote, and (2) is what ships with RHEL 6/CentOS 6, so `homeshick check` always fails `uncheckable` there. As best as I can tell, -q is a noop for 'git ls-remote --heads' when you supply the repo as an argument, so it's safe to remove.