### PR TITLE
Fix fish path resolution for paths with spaces

### DIFF
--- a/homeshick.fish
+++ b/homeshick.fish
@@ -6,9 +6,9 @@
 function homeshick
 	if test \( (count $argv) = 2 -a $argv[1] = "cd" \)
 		cd "$HOME/.homesick/repos/$argv[2]"
-	else if set -q HOMESHICK_DIR 
-		eval $HOMESHICK_DIR/bin/homeshick $argv
+	else if set -q HOMESHICK_DIR
+		eval $HOMESHICK_DIR/bin/homeshick (string escape -- $argv)
 	else
-		eval $HOME/.homesick/repos/homeshick/bin/homeshick $argv
+		eval $HOME/.homesick/repos/homeshick/bin/homeshick (string escape -- $argv)
 	end
 end


### PR DESCRIPTION
It appears to be a fish issue (https://github.com/fish-shell/fish-shell/issues/3708), which is worked around by adding `(string escape -- $argv)` instead of `$argv`.

Fixes #170