### PR TITLE
Make Travis build with bats, csh and fish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,29 @@
 language: bash
+
 dist: trusty
+
 addons:
   apt:
-    sources:
-    - debian-sid
     packages:
     - shellcheck
-    - bats
-    # - expect
+    - expect
+    - tcsh
+
+before_script:
+  - git clone https://github.com/sstephenson/bats.git /tmp/bats
+  - mkdir -p /tmp/local
+  - bash /tmp/bats/install.sh /tmp/local
+  - export PATH=$PATH:/tmp/local/bin
+  - sudo apt-add-repository ppa:fish-shell/release-2 --yes
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install fish
+
 script:
+- fish --version
+- csh --version
 - test/shellcheck
 - bats --tap test/suites
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
The problem was bats, as Debian package sources were mixed with those of Ubuntu because of a missing bats package in Ubuntu. That doesn't work. The issue is fixed by installing bats from source.

Since Ubuntu uses comparatively old versions of packages, fish is added in as a Launchpad repo. This way, the newest fish version is tested.

csh is another interesting bit. On most Unix systems (except Linux) csh is replaced/symlinked to tcsh by default and on Linux actually creates a csh symlink when installing tcsh. This is the one you want, as plain csh is horribly incompatible with practically everything and won't work with the testing script. tcsh does.

Also interesting: http://www.faqs.org/faqs/unix-faq/shell/csh-whynot/