### PR TITLE
Fix argument testing in homeshick.fish

### DIFF
--- a/homeshick.fish
+++ b/homeshick.fish
@@ -4,7 +4,7 @@
 # "homeshick cd CASTLE" to enter a castle.
 
 function homeshick
-	if test \( (count $argv) = 2 -a $argv[1] = "cd" \)
+	if test \( (count $argv) = 2 -a "$argv[1]" = "cd" \)
 		cd "$HOME/.homesick/repos/$argv[2]"
 	else if set -q HOMESHICK_DIR
 		eval $HOMESHICK_DIR/bin/homeshick (string escape -- $argv)

--- a/test/suites/misc.bats
+++ b/test/suites/misc.bats
@@ -30,3 +30,11 @@ load ../helper
 	run grep -q 'nn$' <<<"$output"
 	[ $status -eq 1 ]
 }
+
+@test 'fish function should not print errors when invoked without arguments' {
+	[ "$(type -t fish)" = "file" ] || skip "fish not installed"
+	cmd="source "$HOMESHICK_FN_SRC_FISH"; and $HOMESHICK_FN"
+	local stderr
+	stderr=$( fish <<< "$cmd" 2>&1 >/dev/null )
+	[ -z "$stderr" ]
+}


### PR DESCRIPTION
Hi,
just noticed a small bug in the fish wrapper, which causes it to print error message when invoked without arguments. This PR adds an unit test, and fixes the issue.

Thanks for this cool project BTW!