### PR TITLE
Use HTTPS for Git clone operations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ you have poured your heart into with you to remote computers.
 With it you can begin to focus even more energy on bettering your work environment
 since the benefits are reaped on whichever machine you are using.
 
-However bare bones these machines are, provided that at least bash 3 and git 1.5 are available you can use homeshick.
+However bare bones these machines are, provided that at least Bash 3 and Git 1.5 are available you can use homeshick.
 homeshick can handle multiple dotfile repositories. This means that you can install
 larger frameworks like [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 or a multitude of emacs or vim plugins alongside your own customizations without clutter.
@@ -22,9 +22,9 @@ Quick install
 
 homeshick is installed to your own home directory and does not require root privileges to be installed.
 ```sh
-git clone git://github.com/andsens/homeshick.git $HOME/.homesick/repos/homeshick
+git clone https://github.com/andsens/homeshick.git $HOME/.homesick/repos/homeshick
 ```
-*Note: If you'd like to help testing new features before they are released use `git clone --branch testing git://...`*
+*Note: If you'd like to help testing new features before they are released use `git clone --branch testing https://...`*
 
 To invoke homeshick, source the `homeshick.sh` script from your rc-script:
 ```sh


### PR DESCRIPTION
The `git://` protocol is considered insecure and deprecated, so switching to `https://` is a good idea. This also capitalizes Bash and Git (which are the official casings used by those projects).