### PR TITLE
Speed up refresh operation by reducing exec calls

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -23,12 +23,14 @@ exit_status=$EX_SUCCESS
 
 type git &>/dev/null || err "$EX_SOFTWARE" "git not found in path"
 
-mkdir -p "$repos"
+if [[ ! -d $repos ]]; then
+	mkdir -p "$repos"
+fi
 
 # used in pull.sh
 # shellcheck disable=SC2034
 T_START=$(date +%s)
-GIT_VERSION=$(git --version | grep 'git version' | cut -d ' ' -f 3)
+read -r _ _ GIT_VERSION _ < <(git --version)
 if [[ ! $GIT_VERSION =~ ([0-9]+)(\.[0-9]+){0,3} ]]; then
 	err "$EX_SOFTWARE" "could not determine git version"
 fi

--- a/lib/commands/refresh.sh
+++ b/lib/commands/refresh.sh
@@ -12,10 +12,8 @@ function refresh {
 
 	if [[ -e $fetch_head ]]; then
 		local last_mod
-		local time_now
 		last_mod=$(stat -c %Y "$fetch_head" 2> /dev/null || stat -f %m "$fetch_head")
-		time_now=$(date +%s)
-		if [[ $((time_now-last_mod)) -gt $threshhold ]]; then
+		if [[ $((T_START-last_mod)) -gt $threshhold ]]; then
 			fail "outdated"
 			return "$EX_TH_EXCEEDED"
 		else
@@ -44,10 +42,8 @@ function pull_outdated {
 		# we reset the outdated ones by touching FETCH_HEAD
 		if [[ -e $fetch_head ]]; then
 			local last_mod
-			local time_now
 			last_mod=$(stat -c %Y "$fetch_head" 2> /dev/null || stat -f %m "$fetch_head")
-			time_now=$(date +%s)
-			if [[ $((time_now-last_mod)) -gt $threshhold ]]; then
+			if [[ $((T_START-last_mod)) -gt $threshhold ]]; then
 				outdated_castles+=("$castle")
 				! $BATCH && touch "$fetch_head"
 			fi

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -23,7 +23,8 @@ function home_exists {
 function list_castle_names {
 	while IFS= read -d $'\0' -r repo ; do
 		local reponame
-		reponame=$(basename "${repo%/.git}")
+		reponame="${repo%/.git}"
+		reponame="${reponame##*/}"
 		printf "%s\n" "$reponame"
 	done < <(find -L "$repos" -mindepth 2 -maxdepth 2 -name .git -type d -print0 | sort -z)
 	return "$EX_SUCCESS"


### PR DESCRIPTION
Replace common shell utilities with built-in bash functions to speed
up execution. Also replace call to "date" with T_START that is set when
homeshick first starts.

This speeds up a no-op "homeshick refresh" with 10 castles from 290ms
to 200ms (~31% improvement) on my machine by reducing calls to exec.