### PR TITLE
Add plugin style initialization file for zsh

### DIFF
--- a/homeshick.zsh
+++ b/homeshick.zsh
@@ -1,0 +1,2 @@
+source "$(dirname "$0")/homeshick.sh"
+fpath=("${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}/completions" $fpath)


### PR DESCRIPTION
This little file will allows zsh user to just source a single file to set up homeshick in their shell.

Furthermore you can now easily install homeshick as a plugin with a zsh plugin managers. 

For example with ```zplug``` you can now add the following to your zshrc:

```
export HOMESHICK_DIR="$HOME/.zplug/repos/andsens/homeshick/"
zplug "andsens/homeshick"
```

Any feedback welcome.