### PR TITLE
Alias "list" to "ls"

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -69,7 +69,7 @@ done
 [[ $# -gt 0 ]] || cmd="help"
 
 # Get the subcommand
-valid_commands=(cd clone generate list check updates refresh pull symlink link track help)
+valid_commands=(cd clone generate list ls check updates refresh pull symlink link track help)
 if [[ ! $cmd ]]; then
   # We actually want literal matching of the rhs here, $1 shouldn't be a regexp
   # shellcheck disable=SC2076
@@ -125,7 +125,7 @@ while [[ $# -gt 0 ]]; do
     track)
       [[ ! $castle ]] && castle=$1 || params+=("$1")
       shift; continue ;;
-    list) err "$EX_USAGE" "The 'list' command does not take any arguments" ;;
+    list | ls) err "$EX_USAGE" "The '$1' command does not take any arguments" ;;
     help)
       [[ ! $help_cmd ]] && help_cmd=$1
       shift; continue;;
@@ -164,7 +164,7 @@ case $cmd in
 esac
 
 case $cmd in
-  list)  list           ;;
+  list | ls)  list      ;;
   cd)    help cd        ;; # cd is implemented in the homeshick.{sh,csh} helper script.
   help)  help $help_cmd ;;
   *)

--- a/completions/_homeshick
+++ b/completions/_homeshick
@@ -9,7 +9,7 @@ _homeshick () {
     {-b,--batch}'[Batch-mode: Skip interactive prompt]' \
     {-v,--verbose}'[Verbose-mode: Detailed status output]' \
     {-h,--help}'[Help message]' \
-    '1:commands:(cd clone generate list check refresh pull link track help)' \
+    '1:commands:(cd clone generate list ls check refresh pull link track help)' \
     '*::arguments:->arguments' \
     && ret=0
 

--- a/completions/homeshick-completion.bash
+++ b/completions/homeshick-completion.bash
@@ -67,6 +67,7 @@ _homeshick_complete()
         clone
         generate
         list
+        ls
         check
         refresh
         pull

--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -25,6 +25,7 @@ printf "homes\e[1;34mh\e[0mick uses git in concert with symlinks to track your p
   homeshick help [TASK]               # Show usage of a task
 
  Aliases:
+  ls      # Alias to list
   symlink # Alias to link
   updates # Alias to check
 
@@ -57,9 +58,9 @@ extended_help() {
       printf "Generates a repo prepped for usage with homeshick\n"
       printf "Usage:\n  homeshick generate CASTLE.."
       ;;
-    list)
+    list|ls)
       printf "Lists cloned castles\n"
-      printf "Usage:\n  homeshick list"
+      printf "Usage:\n  homeshick %s" "$1"
       ;;
     check|updates)
       printf "Checks if a castle has been updated on the remote\n"


### PR DESCRIPTION
First of all, thanks - homeshick is great software.

I frequently try to list the available castles using `homeshick ls`
instead of `homeshick list`. I fixed this in my own `.zshrc` but figured
this might be a common typo, so I implemented it in homeshick.

Figured I'd see if this change is welcome.