### PR TITLE
Make homebrew homeshick work seamlessly with fish

### DIFF
--- a/homeshick.fish
+++ b/homeshick.fish
@@ -1,5 +1,7 @@
 # This script should be sourced in the context of your shell like so:
 # source $HOME/.homesick/repos/homeshick/homeshick.fish
+# Alternatively, it can be installed into one of the directories
+# that fish uses to autoload functions (e.g ~/.config/fish/functions)
 # Once the homeshick() function is defined, you can type
 # "homeshick cd CASTLE" to enter a castle.
 
@@ -8,6 +10,8 @@ function homeshick
     cd "$HOME/.homesick/repos/$argv[2]"
   else if set -q HOMESHICK_DIR
     eval $HOMESHICK_DIR/bin/homeshick (string escape -- $argv)
+  else if set homeshick (type -P homeshick)
+    eval $homeshick (string escape -- $argv)
   else
     eval $HOME/.homesick/repos/homeshick/bin/homeshick (string escape -- $argv)
   end


### PR DESCRIPTION
This change makes homeshick.fish find homeshick if it is on the path, without needing to set HOMESHICK_DIR.

(Homebrew installs homeshick on the path, and also
installs homeshick.fish into a function autoloading directory.)