### PR TITLE
overwrite files with same content

### DIFF
--- a/lib/commands/link.sh
+++ b/lib/commands/link.sh
@@ -52,6 +52,14 @@ symlink() {
             ignore 'identical' "$relpath"
           fi
           continue
+        elif [[ ! -L $homepath && -f $homepath && -f $repopath ]] && files_are_same "$homepath" "$repopath"; then
+          # $homepath is a real file, and
+          # $repopath is a real file or a symlinked file, and
+          # $homepath & $repopath files have same contents
+
+          # skip, ie we're ok with forcing link creation.
+          # likely some program doesn't support symlinks and is overwriting them:
+          true
         elif $SKIP; then
           ignore 'exists' "$relpath"
           continue

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -64,9 +64,10 @@ castle() {
 }
 
 is_symlink() {
+  local expected path target
   expected=$1
   path=$2
-  target=$(readlink "$path")
+  target=$(readlink -- "$path")
   [ "$expected" = "$target" ]
 }
 

--- a/test/suites/files_are_same.bats
+++ b/test/suites/files_are_same.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+load ../helper.sh
+
+setup() {
+  create_test_dir
+  # shellcheck source=../../lib/fs.sh
+  source "$HOMESHICK_DIR/lib/fs.sh"
+}
+
+teardown() {
+  delete_test_dir
+}
+
+@test 'success if files have same content' {
+  cat > "$HOME/file1" <<EOF
+    line 1
+      line 2
+EOF
+  cat > "$HOME/file2" <<EOF
+    line 1
+      line 2
+EOF
+  files_are_same "$HOME/file1" "$HOME/file2"
+}
+
+@test 'success if files have same content, even if one is a symlink' {
+  echo 'file contents' > "$HOME/file1"
+  echo 'file contents' > "$HOME/file2"
+  ln -s "$HOME/file2" "$HOME/file2-link"
+  files_are_same "$HOME/file1" "$HOME/file2-link"
+}
+
+@test 'fail if contents differ' {
+  echo 'file contents' > "$HOME/file1"
+  echo 'file content' > "$HOME/file2"
+  ! files_are_same "$HOME/file1" "$HOME/file2"
+}


### PR DESCRIPTION
- this is to cover programs that don't respect symlinks and continuously
  overwrite files. this change makes it so files whose contents match
  their to-be linked target's, should be overwritten by default.
- add new files_are_same() function in /lib/fs.sh to perform file
  content comparison.
- update tests