### PR TITLE
cd to a repo before running git ls-remote

### DIFF
--- a/lib/commands/check.sh
+++ b/lib/commands/check.sh
@@ -22,7 +22,7 @@ check() {
   remote_url=$(cd "$repo" && git config "remote.$remote_name.url" 2>/dev/null)
   # Get the HEAD of the current branch on the upstream remote
   local remote_head
-  remote_head=$(git ls-remote --heads "$remote_url" "$branch" 2>/dev/null | cut -f 1)
+  remote_head=$(cd "$repo" && git ls-remote --heads "$remote_url" "$branch" 2>/dev/null | cut -f 1)
   if [[ $remote_head ]]; then
     local local_head
     local_head=$(cd "$repo" && git rev-parse HEAD)


### PR DESCRIPTION
This is necessary to allow `git ls-remote` to pick up repository-specific information, such as values for core.sshCommand or http.userAgent that are stored in the repository's .git/config file.

I'm not sure how best to add coverage for this in the test suites, as all the configuration options that seem relevant to me are ones that require a remote server. Setting up a temporary local HTTP or SSH server as part of the test suites seems like overkill for what is – in my opinion – a very safe change.

I've also not actually managed to run the test suites either. I tried to follow the guide at https://github.com/andsens/homeshick/wiki/Testing, but then running `test/run` seems to have the test suite return success immediately, even when I deliberately broke a test, while running `test/suites/cd.bats` first complains that "test/suites/../helper.sh.bash does not exist", then after renaming `helper.sh`, that "/usr/local/bats/support/load.bash does not exist", and that's a file that doesn't seem to be part of either the [abandoned bats repo referenced in the testing page](https://github.com/sstephenson/bats) or the [currently maintained bats repo](https://github.com/bats-core/bats-core). I'm guessing that setup might be something specific to the homebrew packaging of bats...