### PR TITLE
Don't assume changing directory will work

### DIFF
--- a/lib/commands/clone.sh
+++ b/lib/commands/clone.sh
@@ -31,7 +31,7 @@ clone() {
     success
 
     pending 'submodules' "$git_repo"
-    git_out=$(cd "$repo_path"; git submodule update --init 2>&1) || \
+    git_out=$(cd "$repo_path" && git submodule update --init 2>&1) || \
       err "$EX_SOFTWARE" "Unable to clone submodules for $git_repo. Git says:" "$git_out"
     success
   fi


### PR DESCRIPTION
For consistency with other uses of `cd`, make following commands
conditional on the `cd` command completing successfully when
initializing submodules as part of a clone, rather than assuming it will
complete successfully and carrying on regardless.
