### PR TITLE
Remove need for getting URL for ls-remote

### DIFF
--- a/lib/commands/check.sh
+++ b/lib/commands/check.sh
@@ -17,12 +17,10 @@ check() {
   branch=${ref#refs/heads/}
   # Get the upstream remote of that branch
   local remote_name
-  local remote_url
   remote_name=$(cd "$repo" && git config "branch.$branch.remote" 2>/dev/null)
-  remote_url=$(cd "$repo" && git config "remote.$remote_name.url" 2>/dev/null)
   # Get the HEAD of the current branch on the upstream remote
   local remote_head
-  remote_head=$(cd "$repo" && git ls-remote --heads "$remote_url" "$branch" 2>/dev/null | cut -f 1)
+  remote_head=$(cd "$repo" && git ls-remote --heads "$remote_name" "$branch" 2>/dev/null | cut -f 1)
   if [[ $remote_head ]]; then
     local local_head
     local_head=$(cd "$repo" && git rev-parse HEAD)


### PR DESCRIPTION
Now that `git ls-remote` is run from within a repo, we can refer to the
remote by name, rather than needing to specify the URL.  Do that, in the
name of simplifying the code and removing the need to worry about URLs
at all during `homeshick check`.