### PR TITLE
Silence homeshick binary finding in fish shell

### DIFF
--- a/homeshick.fish
+++ b/homeshick.fish
@@ -10,7 +10,7 @@ function homeshick
     cd "$HOME/.homesick/repos/$argv[2]"
   else if set -q HOMESHICK_DIR
     eval $HOMESHICK_DIR/bin/homeshick (string escape -- $argv)
-  else if set homeshick (type -P homeshick)
+  else if set homeshick (type -P homeshick 2> /dev/null)
     eval $homeshick (string escape -- $argv)
   else
     eval $HOME/.homesick/repos/homeshick/bin/homeshick (string escape -- $argv)


### PR DESCRIPTION
With a recent system update, type -P in fish shell started printing an error message in case no homeshick binary exists on PATH. This is an expected condition in the homeshick fish wrapper and therefore the error message should probably not reach the user.