### PR TITLE
Add --git option to clone command

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -41,6 +41,7 @@ SKIP=false
 FORCE=false
 BATCH=false
 VERBOSE=false
+GIT=false
 
 # Retrieve all the flags preceeding a subcommand
 while [[ $# -gt 0 ]]; do
@@ -59,6 +60,7 @@ while [[ $# -gt 0 ]]; do
       -f | --force) FORCE=true ; shift; continue ;;
       -b | --batch) BATCH=true ; shift; continue ;;
       -v | --verbose) VERBOSE=true ; shift; continue ;;
+      -g | --git) GIT=true ; shift; continue ;;
       *)     err "$EX_USAGE" "Unknown option '$1'" ;;
     esac
   else

--- a/completions/_homeshick
+++ b/completions/_homeshick
@@ -8,6 +8,7 @@ _homeshick () {
     '(-f --force)'{-s,--skip}'[Skip files that already exist]' \
     {-b,--batch}'[Batch-mode: Skip interactive prompt]' \
     {-v,--verbose}'[Verbose-mode: Detailed status output]' \
+    {-g,--git}'[Git-mode: Use git protocol for GitHub shorthand clone]' \
     {-h,--help}'[Help message]' \
     '1:commands:(cd clone generate list ls check refresh pull link track help)' \
     '*::arguments:->arguments' \

--- a/completions/homeshick-completion.bash
+++ b/completions/homeshick-completion.bash
@@ -77,8 +77,8 @@ _homeshick_complete()
         symlink
         updates
     '
-    local -r short_opts='-q      -s     -f      -b      -v'
-    local -r long_opts='--quiet --skip --force --batch --verbose'
+    local -r short_opts='-q      -s     -f      -b      -v      -g'
+    local -r long_opts='--quiet --skip --force --batch --verbose --git'
     local -r protocols='file ftp ftps git http https rsync ssh'
 
     # Scan through the command line and find the homeshick command

--- a/completions/homeshick.fish
+++ b/completions/homeshick.fish
@@ -44,6 +44,7 @@ complete -f -c homeshick -s s -l skip -d 'Skip files that already exist'
 complete -f -c homeshick -s f -l force -d 'Overwrite files that already exist'
 complete -f -c homeshick -s b -l batch -d 'Batch-mode: Skip interactive prompts / Choose the default'
 complete -f -c homeshick -s v -l verbose -d 'Verbose-mode: Detailed status output'
+complete -f -c homeshick -s g -l git -d 'Git-mode: Use git protocol for GitHub shorthand clone'
 
 # cd
 complete -f -c homeshick -n '__fish_homeshick_needs_command' -a cd -r -d 'Enter a castle'

--- a/lib/commands/clone.sh
+++ b/lib/commands/clone.sh
@@ -10,7 +10,11 @@ clone() {
       msg="${msg} use \`homeshick clone ./$git_repo' to circumvent the github shorthand"
       warn 'clone' "$msg"
     fi
-    git_repo="https://github.com/$git_repo.git"
+    if ${GIT}; then
+      git_repo="git@github.com:$git_repo.git"
+    else
+      git_repo="https://github.com/$git_repo.git"
+    fi
   fi
   local repo_path
   # repos is a global variable

--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -35,6 +35,7 @@ printf "homes\e[1;34mh\e[0mick uses git in concert with symlinks to track your p
    -f, [--force]    # Overwrite files that already exist
    -b, [--batch]    # Batch-mode: Skip interactive prompts / Choose the default
    -v, [--verbose]  # Verbose-mode: Detailed status output
+   -g, [--git]      # Git-mode: Use git protocol for GitHub shorthand clone
 
  Note:
   To check, refresh, pull or symlink all your castles

--- a/test/suites/clone.bats
+++ b/test/suites/clone.bats
@@ -31,6 +31,12 @@ EOF
   )
 }
 
+@test 'clone with github shorthand and --git flag' {
+  $EXPECT_INSTALLED || skip 'expect not installed'
+  ping -c 1 -w 3 github.com || ping -c 1 -t 3 github.com || skip 'github not reachable'
+  homeshick --batch --git clone andsens/rc-files
+}
+
 @test 'clone a repo' {
   fixture 'rc-files'
   homeshick --batch clone "$REPO_FIXTURES/rc-files"


### PR DESCRIPTION
When using the shorthand notation for the clone command (homeshick clone
<user>/<repo>), homeshick converts this to a GitHub repo with the https
protocol (https://github.com/<user\>/\<repo\>.git).

This can be inconvenient if it is a private repo, as you then have to
type your password. For such cases, using the git protocol might be
preferred.

This commit introduces a --git option that, when used, uses the Git
protocol instead: git@github.com:\<user\>/\<repo\>.git

That option is ignored for other commands or full repo addresses.