### PR TITLE
Fix ls aliasing

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -157,6 +157,9 @@ case $cmd in
   updates)
     # shellcheck source=../lib/commands/check.sh
     source "$homeshick/lib/commands/check.sh" ;;
+  ls)
+    # shellcheck source=../lib/commands/list.sh
+    source "$homeshick/lib/commands/list.sh" ;;
   *)
     # Don't know what will be included, so just disable the rule
     # shellcheck disable=SC1090


### PR DESCRIPTION
Doing a "homeshick ls" would throw an error like this:

	/home/martin/.homesick/repos/homeshick/bin/homeshick: line 163: /home/martin/.homesick/repos/homeshick/lib/commands/ls.sh: No such file or directory
	/home/martin/.homesick/repos/homeshick/bin/homeshick: line 167: list: command not found

"ls" is an alias to "list". Follow what is done for the other aliases
and just source the right command explicitly.

Fixes: 387df51b6314 (Alias "ls" to "list" command)