### PR TITLE
add a default .gitconfig file to the test harness

### DIFF
--- a/test/helper.sh
+++ b/test/helper.sh
@@ -21,6 +21,9 @@ create_test_dir() {
   HOME="$_TMPDIR/home"
   NOTHOME="$_TMPDIR/nothome"
   mkdir "$REPO_FIXTURES" "$HOME" "$NOTHOME"
+
+  git config --global init.defaultBranch master
+  git config --global protocol.file.allow always
 }
 
 delete_test_dir() {


### PR DESCRIPTION
This fixes the test cases that started failing with Git 2.38.1:

* https://github.com/git/git/blob/master/Documentation/RelNotes/2.38.1.txt
* https://github.com/git/git/blob/master/Documentation/RelNotes/2.30.6.txt

It also supresses the annoying message about the default branch name.