### PR TITLE
Provide test dependencies as submodules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,9 +39,6 @@ jobs:
         git clone --depth 1 --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats
         sudo /tmp/bats/install.sh /usr/local
         rm -rf /tmp/bats
-        sudo git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-support.git /usr/local/bats/support
-        sudo git clone --depth 1 --branch v2.0.0 https://github.com/bats-core/bats-assert.git /usr/local/bats/assert
-        sudo git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-file.git /usr/local/bats/file
     - name: Checkout the project
       uses: actions/checkout@v3
     - name: Cache bash versions
@@ -55,6 +52,8 @@ jobs:
       run: |
         test/get_bash.sh "${{ matrix.bash-version }}"
         echo "$PWD/test/bash-versions/bash-${{ matrix.bash-version }}" >> "$GITHUB_PATH"
+    - name: Download bats libraries
+      run: test/get_bats_libs.sh
     - name: Test
       run: |
         echo "::add-matcher::.github/bats.json"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         wget -O- https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz | \
         sudo tar -xJC /usr/local/bin --strip-components 1 shellcheck-v0.7.1/shellcheck
     - name: Checkout the project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Lint with shellcheck
       run: |
         echo "::add-matcher::.github/shellcheck.json"
@@ -43,9 +43,9 @@ jobs:
         sudo git clone --depth 1 --branch v2.0.0 https://github.com/bats-core/bats-assert.git /usr/local/bats/assert
         sudo git clone --depth 1 --branch v0.3.0 https://github.com/bats-core/bats-file.git /usr/local/bats/file
     - name: Checkout the project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Cache bash versions
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: bash-version
       with:

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 /setup.sh
 /bash-versions
+/bats

--- a/test/get_bats_libs.sh
+++ b/test/get_bats_libs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+lib_path=$(dirname "${BASH_SOURCE[0]}")/bats/lib
+
+function install_bats_lib {
+	mkdir -p "$lib_path/$1"
+	curl -L --no-progress-meter "https://api.github.com/repos/bats-core/bats-$1/tarball/$2" | tar xz --strip=1 -C "$lib_path/$1"
+}
+
+install_bats_lib support v0.3.0
+install_bats_lib assert v2.0.0
+install_bats_lib file v0.3.0

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-load /usr/local/bats/support/load.bash
-load /usr/local/bats/assert/load.bash
-load /usr/local/bats/file/load.bash
+load ../bats/lib/support/load.bash
+load ../bats/lib/assert/load.bash
+load ../bats/lib/file/load.bash
 
 setup_file() {
   check_expect

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ ! -d "$(dirname "${BASH_SOURCE[0]}")/bats/lib/support" ]]; then
+  printf "bats libraries are missing - run get_bats_libs.sh"
+  exit 1
+fi
+
 load ../bats/lib/support/load.bash
 load ../bats/lib/assert/load.bash
 load ../bats/lib/file/load.bash


### PR DESCRIPTION
It used to be that homeshick could be tested just by cloning the repository and running `bats test/suites`. Unfortunately, since the introduction of the 3 bats libraries, this is no longer the case.

[The wiki](https://github.com/andsens/homeshick/wiki/Testing) specifies how the test dependencies should be installed to make it work, but there are some disadvantages to this approach:

 * Root access is required to install the dependencies under `/usr/local/`.
 * The process of setting up a development environment (locally) is cumbersome.

With this PR, I propose turning the bats dependencies into Git submodules of homeshick itself. This is also [the approach suggested by the bats-core developers.](https://bats-core.readthedocs.io/en/stable/tutorial.html) The advantages of this are:

 * Anyone just wanting to use homeshick can clone it as usual, which will produce the same result as before, except some additional metadata.
 * Anyone who wants to run test cases locally can just run `git clone --recurse-submodules ...` (or `git submodule update --init` on an existing repository) to get a complete setup where running `bats test/suites` works as expected.
 * If and when the dependencies are changed, it is not necessary to change the runtime environment.

In case this PR is accepted, I volunteer to change the wiki page about testing accordingly, too.