### PR TITLE
Add optional directory argument to `cd` command

### DIFF
--- a/bin/homeshick
+++ b/bin/homeshick
@@ -141,7 +141,7 @@ if [[ ${#params[@]} -eq 0 ]]; then
         params+=("$name")
       done < <(list_castle_names) ;;
     # These commands require parameters, show the help message instead
-    cd | clone | generate | track) help_cmd=$cmd; cmd="help"; exit_status=$EX_USAGE ;;
+    cd | clone | generate | track) help_err "$cmd";;
   esac
 fi
 

--- a/bin/homeshick
+++ b/bin/homeshick
@@ -150,7 +150,9 @@ fi
 
 # Include the file that implements the invoked command
 case $cmd in
-  cd) ;;
+  cd)
+    # shellcheck source=../lib/commands/cd.sh
+    source "$homeshick/lib/commands/cd.sh" ;;
   symlink)
     # shellcheck source=../lib/commands/link.sh
     source "$homeshick/lib/commands/link.sh" ;;
@@ -168,7 +170,7 @@ esac
 
 case $cmd in
   list | ls)  list      ;;
-  cd)    help cd        ;; # cd is implemented in the homeshick.{sh,csh} helper script.
+  cd)    homeshick_cd "${params[@]}" ;;
   help)  help $help_cmd ;;
   *)
     for param in "${params[@]}"; do

--- a/homeshick.csh
+++ b/homeshick.csh
@@ -2,16 +2,28 @@
 #
 #   alias homeshick "source $HOME/.homesick/repos/homeshick/homeshick.csh"
 #
-if ( "$1" == "cd" && "x$2" != "x" ) then
-    if ( -d "$HOME/.homesick/repos/$2/home" ) then
-        cd "$HOME/.homesick/repos/$2/home"
-    else
-        cd "$HOME/.homesick/repos/$2"
-    endif
+
+set HOMESHICK_STATUS=0
+if ( $?HOMESHICK_DIR ) then
+    set HOMESHICK_BIN=$HOMESHICK_DIR/bin/homeshick
 else
-    if ( $?HOMESHICK_DIR ) then
-        $HOMESHICK_DIR/bin/homeshick $*
-    else
-        $HOME/.homesick/repos/homeshick/bin/homeshick $*
-    endif
+    set HOMESHICK_BIN=$HOME/.homesick/repos/homeshick/bin/homeshick
 endif
+if ( "$1" == "cd" ) then
+    set HOMESHICK_REPO_TARGET="`$HOMESHICK_BIN $*`"
+    if ( "$HOMESHICK_REPO_TARGET" =~ /* ) then
+        cd "$HOMESHICK_REPO_TARGET"
+        set HOMESHICK_STATUS=$status
+    else
+        if ("$HOMESHICK_REPO_TARGET" != "") then
+            printf '%s\n' $HOMESHICK_REPO_TARGET:q
+        endif
+        set HOMESHICK_STATUS=64
+    endif
+    unset HOMESHICK_REPO_TARGET
+else
+    $HOMESHICK_BIN $*
+    set HOMESHICK_STATUS=$status
+endif
+unset HOMESHICK_BIN
+set status=$HOMESHICK_STATUS

--- a/homeshick.fish
+++ b/homeshick.fish
@@ -6,13 +6,22 @@
 # "homeshick cd CASTLE" to enter a castle.
 
 function homeshick
-  if test \( (count $argv) = 2 -a "$argv[1]" = "cd" \)
-    cd "$HOME/.homesick/repos/$argv[2]"
-  else if set -q HOMESHICK_DIR
-    eval $HOMESHICK_DIR/bin/homeshick (string escape -- $argv)
+  if set -q HOMESHICK_DIR
+    set -f homeshick_bin $HOMESHICK_DIR/bin/homeshick
   else if set homeshick (type -P homeshick 2> /dev/null)
-    eval $homeshick (string escape -- $argv)
+    set -f homeshick_bin $homeshick 
   else
-    eval $HOME/.homesick/repos/homeshick/bin/homeshick (string escape -- $argv)
+    set -f homeshick_bin $HOME/.homesick/repos/homeshick/bin/homeshick
+  end
+  if test \( "$argv[1]" = "cd" \)
+    set -l homeshick_target_dir "$(eval $homeshick_bin (string escape -- $argv))"
+    if string match -q "/*" "$homeshick_target_dir"
+      cd "$homeshick_target_dir"
+    else
+      test -n "$homeshick_target_dir"; and printf '%s\n' "$homeshick_target_dir"
+      return 64
+    end
+  else
+    eval $homeshick_bin (string escape -- $argv)
   end
 end

--- a/homeshick.sh
+++ b/homeshick.sh
@@ -5,11 +5,20 @@
 # "homeshick cd CASTLE" to enter a castle.
 
 homeshick () {
-  if [ "$1" = "cd" ] && [ -n "$2" ]; then
+  HOMESHICK_STATUS=0
+  HOMESHICK_BIN="${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}/bin/homeshick"
+  if [ "$1" = "cd" ]; then
+    HOMESHICK_REPO_TARGET="$("$HOMESHICK_BIN" "$@")"
     # We want replicate cd behavior, so don't use cd ... ||
     # shellcheck disable=SC2164
-    cd "$HOME/.homesick/repos/$2"
+    case "$HOMESHICK_REPO_TARGET" in
+      /*) cd "$HOMESHICK_REPO_TARGET"; HOMESHICK_STATUS=$?;;
+      *) [ -n "$HOMESHICK_REPO_TARGET" ] && printf '%s\n' "$HOMESHICK_REPO_TARGET"; HOMESHICK_STATUS=64;;
+    esac
   else
-    "${HOMESHICK_DIR:-$HOME/.homesick/repos/homeshick}/bin/homeshick" "$@"
+    "$HOMESHICK_BIN" "$@"
+    HOMESHICK_STATUS=$?
   fi
+  unset HOMESHICK_BIN HOMESHICK_REPO_TARGET
+  return "$HOMESHICK_STATUS"
 }

--- a/lib/commands/cd.sh
+++ b/lib/commands/cd.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+homeshick_cd() {
+  [[ ! $1 ]] && help_err cd
+
+  local castle=$1
+
+  # repos is a global variable
+  # shellcheck disable=SC2154
+  local repo="$repos/$castle"
+  local repopath
+
+  if [[ -n "$2" ]] && [[ -d "$repo" ]]; then
+    local dirname
+    dirname=$(abs_path "$2")
+    if [[ $dirname != $HOME/* ]] && [[ $dirname != "$HOME" ]]; then
+      err "$EX_ERR" "The directory $dirname must be in your home directory."
+    fi
+    if [[ ! -d $dirname ]]; then
+      err "$EX_ERR" "$dirname does not exist or is not a directory."
+    fi
+    home_exists 'cd' "$castle"
+
+    local relpath
+    if [[ $dirname = "$HOME" ]]; then
+      relpath=""
+    else
+      relpath=${dirname#$HOME/}
+    fi
+    local relpath_in_repo="home/$relpath"
+    repopath="$repo/$relpath_in_repo"
+    if [[ ! -e $repopath ]]; then
+      err "$EX_ERR" "$relpath is not being tracked in $castle."
+    fi
+  else
+    repopath="$repo"
+  fi
+
+  printf '%s\n' "$repopath"
+  return "$EX_SUCCESS"
+}

--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -13,7 +13,7 @@ printf "homes\e[1;34mh\e[0mick uses git in concert with symlinks to track your p
  Usage: homeshick [options] TASK
 
  Tasks:
-  homeshick cd CASTLE                 # Enter a castle
+  homeshick cd CASTLE [DIRECTORY]     # Enter a castle
   homeshick clone URI..               # Clone URI as a castle for homeshick
   homeshick generate CASTLE..         # Generate a castle repo
   homeshick list                      # List cloned castles
@@ -48,7 +48,12 @@ extended_help() {
     cd)
       printf "Enters a castle's home directory.\n"
       printf "NOTE: For this to work, homeshick must be invoked via homeshick.{sh,csh,fish}.\n\n"
-      printf "Usage:\n  homeshick cd CASTLE"
+      printf "Usage:\n  homeshick cd CASTLE [DIRECTORY]"
+      printf "\n\nThe optional DIRECTORY argument will change to the specified directory, relative\n"
+      printf "to \$HOME, within CASTLE/home. If specified, DIRECTORY must be inside \$HOME and\n"
+      printf "contain files tracked by CASTLE.\n\n"
+      printf "Tip:\n  Use 'homeshick cd CASTLE .' to change to the castle directory that corresponds\n"
+      printf "  to the current directory."
       ;;
     clone)
       printf "Clones URI as a castle for homeshick\n"

--- a/lib/commands/track.sh
+++ b/lib/commands/track.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 track() {
-  [[ ! $1 || ! $2 ]] && help track
+  [[ ! $1 || ! $2 ]] && help_err track
   local castle=$1
   local filename
   filename=$(abs_path "$2")

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -26,10 +26,13 @@ err() {
 }
 
 help_err() {
+  cmd="$1"
+  reason="${2:-"Missing command line argument(s)"}"
+  shift $(($# < 2 ? 1 : 2))
   # shellcheck source=commands/help.sh disable=SC2154
   source "$homeshick/lib/commands/help.sh"
-  extended_help "$1"
-  exit "$EX_USAGE"
+  extended_help "$cmd"
+  err "$EX_USAGE" "$reason" "$@"
 }
 
 status() {

--- a/test/suites/cd.bats
+++ b/test/suites/cd.bats
@@ -28,6 +28,39 @@ teardown() {
   [ "$dotfiles_dir" = "$result" ]
 }
 
+@test 'cd to dotfiles castle subdirectory relative to HOME' {
+  castle 'dotfiles'
+  local dotfiles_dir=$HOME/.homesick/repos/dotfiles/home/.config/foo.conf
+  local home_dir=$HOME/.config/foo.conf
+  mkdir -p "$home_dir"
+  local result
+  result=$(homeshick cd dotfiles $home_dir && pwd)
+  [ "$dotfiles_dir" = "$result" ]
+}
+
+@test 'cd to dotfiles castle subdirectory relative to PWD' {
+  castle 'dotfiles'
+  local dotfiles_dir=$HOME/.homesick/repos/dotfiles/home/.config/foo.conf
+  local home_dir=$HOME/.config/foo.conf
+  mkdir -p "$home_dir"
+  cd "$home_dir"
+  local result
+  result=$(homeshick cd dotfiles . && pwd)
+  [ "$dotfiles_dir" = "$result" ]
+}
+
+@test 'cd to dotfiles castle subdirectory relative to NOTHOME should fail' {
+  castle 'dotfiles'
+  local dotfiles_dir=$HOME/.homesick/repos/dotfiles/home/.config/foo.conf
+  local nothome_dir=$NOTHOME/.config/foo.conf
+  mkdir -p "$nothome_dir"
+  cd "$nothome_dir"
+  local result
+  result=$(! homeshick cd dotfiles . 2>/dev/null && pwd)
+  >&2 printf '"%s" = "%s"?\n' "$nothome_dir" "$result"
+  [ "$nothome_dir" = "$result" ]
+}
+
 @test 'cd to my_module castle' {
   castle 'module-files'
   homeshick --batch clone "$REPO_FIXTURES/my_module"

--- a/test/suites/cd.bats
+++ b/test/suites/cd.bats
@@ -137,7 +137,7 @@ EOF
   # fish $PWD has all symlinks resolved
   local dotfiles_dir
   dotfiles_dir=$(cd "$HOME/.homesick/repos/dotfiles" && pwd -P)
-  cmd="source \"$HOMESHICK_DIR/homeshick.fish\"; and homeshick cd dotfiles; and pwd"
+  cmd="source \"$HOMESHICK_DIR/homeshick.fish\"; and homeshick cd dotfiles; and pwd -P"
   local result
   result=$( fish <<< "$cmd" )
   [ "$dotfiles_dir" = "$result" ]

--- a/test/suites/homeshick_dir.bats
+++ b/test/suites/homeshick_dir.bats
@@ -30,8 +30,10 @@ teardown() {
 
 @test 'csh with homeshick_dir override' {
   [ "$(type -t csh)" = "file" ] || skip "csh not installed"
-  cmd="set HOMESHICK_DIR=/nowhere; source \"$HOMESHICK_DIR/homeshick.csh\""
+  # "source" command expected to error, but csh must exit 0 or test will fail
+  cmd="set HOMESHICK_DIR=/nowhere; source \"$HOMESHICK_DIR/homeshick.csh\"; exit 0"
   local result
+  >&2 printf 'HOMESHICK_DIR=%s\n' "$HOMESHICK_DIR"
   result=$( csh <<< "$cmd" 2>&1 >/dev/null )
   [[ "$result" =~ "/nowhere/" ]] || false
 }


### PR DESCRIPTION
Adds the ability to specify an optional second argument to the
`homeshick cd` command that will change directory into the castle repo's
subdirectory that corresponds to the given directory, as long as it is
within `$HOME` and is tracked by the castle.

Most convenient to use when `$PWD` is within `$HOME`:
```
homeshick cd CASTLE .
```

### Other changes
* Some fixes that ensure test suite can run on very recent (late 2022) versions of Git and Bash.
* Improvements to error reporting of command line usage errors.