### PR TITLE
editorconfig: match documented code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.sh]
-indent_style = tab
+indent_size = 2
+indent_style = space
 
 [*.md]
 max_line_length = 80


### PR DESCRIPTION
According to the [Contribution guidelines](https://github.com/andsens/homeshick/blob/master/CONTRIBUTING.md), shell scripts should be indented by 2 spaces, so make the `.editorconfig` match that.