### PR TITLE
link: only log ignored castles with verbose

### DIFF
--- a/lib/commands/link.sh
+++ b/lib/commands/link.sh
@@ -8,7 +8,9 @@ symlink() {
   # shellcheck disable=SC2154
   local repo="$repos/$castle"
   if [[ ! -d $repo/home ]]; then
-    ignore 'ignored' "$castle"
+    if $VERBOSE; then
+      ignore 'ignored' "$castle"
+    fi
     return "$EX_SUCCESS"
   fi
   # Run through the repo files using process substitution.


### PR DESCRIPTION
The link command ignores castles without a `home` directory, and logs a message about it.

I think this messages should only be shown when verbose output is enabled, similar to the treatment of files whose links remain unchanged. This also matches the *no news is good news* principle most Unix programs operate by, where no output means it either did nothing, or exactly what you asked for.