### PR TITLE
refresh: batch mode also pulls by default

### DIFF
--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -18,7 +18,7 @@ printf "homes\e[1;34mh\e[0mick uses git in concert with symlinks to track your p
   homeshick generate CASTLE..         # Generate a castle repo
   homeshick list                      # List cloned castles
   homeshick check [CASTLE..]          # Check a castle for updates
-  homeshick refresh [DAYS [CASTLE..]] # Check if a castle needs refreshing
+  homeshick refresh [DAYS [CASTLE..]] # Refresh a castle at regular intervals
   homeshick pull [CASTLE..]           # Update a castle
   homeshick link [CASTLE..]           # Symlinks all dotfiles from a castle
   homeshick track CASTLE FILE..       # Add a file to a castle
@@ -67,8 +67,8 @@ extended_help() {
       printf "Usage:\n  homeshick %s [CASTLE..]" "$1"
       ;;
     refresh)
-      printf "Checks if a castle has not been pulled in DAYS days.\n"
-      printf "The default is one week.\n"
+      printf "Checks when a castle was last pulled, and, if it was more than DAYS days ago,\n"
+      printf "pulls updates from the remote. The default interval is one week.\n"
       printf "Usage:\n  homeshick refresh [DAYS] [CASTLE..]"
       ;;
     pull)

--- a/lib/commands/refresh.sh
+++ b/lib/commands/refresh.sh
@@ -66,7 +66,7 @@ ask_pull() {
       msg="The castles $* are outdated."
       IFS=$OIFS
     fi
-    if prompt_no 'refresh' "$msg" 'pull?'; then
+    if prompt_no 'refresh' "$msg" 'pull?' 0; then
       # shellcheck source=pull.sh disable=SC2154
       source "$homeshick/lib/commands/pull.sh"
       for castle in "$@"; do

--- a/lib/prompt.sh
+++ b/lib/prompt.sh
@@ -36,6 +36,7 @@ prompt_no() {
   local status=$1
   local message=$2
   local prompt=$3
+  local batch_default=${4:-2}
   local result=-1
 
   # global vars
@@ -69,8 +70,12 @@ prompt_no() {
       pending "$pending_status" "$pending_message"
     done
   else
-    pending "$prompt" "BATCH - No"
-    result=2
+    result=$batch_default
+    if $TALK; then
+      local response_txt
+      response_txt=$(if [[ $result == 0 ]]; then echo Yes; else echo No; fi)
+      pending "$prompt" "BATCH - $response_txt"
+    fi
   fi
   if [[ $result == 0 ]]; then
     success
@@ -78,5 +83,5 @@ prompt_no() {
     fail
   fi
   TALK=$OTALK
-  return $result
+  return "$result"
 }

--- a/test/suites/refresh.bats
+++ b/test/suites/refresh.bats
@@ -14,8 +14,6 @@ teardown() {
 
 @test 'refresh a freshly cloned castle' {
   castle 'rc-files'
-  run homeshick refresh -b rc-files
-  [ $status -eq 87 ] # EX_TH_EXCEEDED
 
   $EXPECT_INSTALLED || skip 'expect not installed'
   open_bracket="\\u005b"
@@ -41,19 +39,17 @@ EOF
   castle 'rc-files'
   homeshick pull rc-files # creates the FETCH_HEAD file
 
-  local fetch_head
+  local fetch_head="$HOME/.homesick/repos/rc-files/.git/FETCH_HEAD"
+  [ -f "$fetch_head" ]
   local timestamp
-  fetch_head="$HOME/.homesick/repos/rc-files/.git/FETCH_HEAD"
   system=$(uname -a)
   if [[ "$system" =~ "Linux" ]]; then
-    timestamp=$(date -d@$(($(date +%s)-6*86400)) '+%Y%m%d%H%M.%S')
+    timestamp=$(date -d "now - 8 days")
   else
     # assume BSD system
-    timestamp=$(date -r $(($(date +%s)-6*86400)) '+%Y%m%d%H%M.%S')
+    timestamp=$(date -v -8d "+%Y-%m-%dT%H:%M:%S")
   fi
-  touch -t "$timestamp" "$fetch_head"
-  run homeshick refresh -b rc-files
-  [ $status -eq 87 ] # EX_TH_EXCEEDED
+  touch -d "$timestamp" "$fetch_head"
 
   $EXPECT_INSTALLED || skip 'expect not installed'
   open_bracket="\\u005b"
@@ -96,8 +92,6 @@ EOF
 
 @test 'refresh a castle with spaces in name' {
   castle 'repo with spaces in name'
-  run homeshick refresh -b 'repo with spaces in name'
-  [ $status -eq 87 ] # EX_TH_EXCEEDED
 
   $EXPECT_INSTALLED || skip 'expect not installed'
   open_bracket="\\u005b"


### PR DESCRIPTION
While being a great tool, `homeshick` can be a bit awkward when used in an automated fashion. Its `--batch` mode means "pick the (safe) default option" for every user prompt, which has the unfortunate effect of making most commands rather impotent when run in batch mode.

Because of this, I currently have to write `echo 'y' | homeshick refresh` to automate the updating of all castles at regular intervals, which is a bit corny. I'd much prefer to just write `homeshick --batch refresh`.

In this pull-request, I propose a way to achieve that by allowing commands to change the default prompt response when running in batch mode. The initial application is the *refresh* command.

This implies changing the meaning of `--batch` mode to be "just do what's expected without bothering me" in order to make it more suitable for automation. While still requiring `--force` to make potentially destructive changes, of course.