### PR TITLE
Fix timestamp formatting in test case

### DIFF
--- a/test/suites/refresh.bats
+++ b/test/suites/refresh.bats
@@ -44,7 +44,7 @@ EOF
   local timestamp
   system=$(uname -a)
   if [[ "$system" =~ "Linux" ]]; then
-    timestamp=$(date -d "now - 8 days")
+    timestamp=$(date -d "now - 8 days" "+%Y-%m-%dT%H:%M:%S")
   else
     # assume BSD system
     timestamp=$(date -v -8d "+%Y-%m-%dT%H:%M:%S")


### PR DESCRIPTION
Without it,  there's a test failure (on Linux, with LC_TIME=de_CH.UTF-8):

```
 ✗ refresh a castle that was pulled 8 days ago
   (in test file test/suites/refresh.bats, line 52)
     `touch -d "$timestamp" "$fetch_head"' failed
         pull rc-filesles
   touch: invalid date format ‘Sa 13 Jun 2026 12:42:40 CEST’
```